### PR TITLE
Resolve pytest PYTHONPATH issue and make tests easier to work with

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,11 +63,9 @@ before_script:
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then  docker-compose up -d; fi
 script:
   # Unit tests
-  - travis_wait 15 pytest --runslow --durations=20
+  - travis_wait 15 pytest --run-slow --durations=20 tests/unit_tests
   # Integration tests, require docker so only run on linux
-  - cd tests/integration_tests
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then travis_wait 15 pytest; fi
-  - cd ../..
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then travis_wait 15 pytest --run-integration tests/integration_tests ; fi
   - pip install flake8
   - flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
 after_script:

--- a/__init__.py
+++ b/__init__.py
@@ -1,2 +1,0 @@
-from mindsdb_native import *
-name = "mindsdb"

--- a/mindsdb_native/__about__.py
+++ b/mindsdb_native/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'mindsdb_native'
 __package_name__ = 'mindsdb_native'
-__version__ = '1.99.1'
+__version__ = '1.99.4'
 __description__ = "MindsDB's goal is to make it very simple for developers to use the power of artificial neural networks in their projects."
 __email__ = "jorge@mindsdb.com"
 __author__ = 'MindsDB Inc'

--- a/mindsdb_native/libs/controllers/predictor.py
+++ b/mindsdb_native/libs/controllers/predictor.py
@@ -13,7 +13,6 @@ from mindsdb_native.config import CONFIG
 from mindsdb_native.libs.controllers.transaction import Transaction
 from mindsdb_native.libs.constants.mindsdb import *
 from mindsdb_native.libs.helpers.general_helpers import check_for_updates
-
 from pathlib import Path
 
 class Predictor:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,0 @@
-[pytest]
-testpaths=tests/unit_tests
-addopts=--randomly-seed=42 -p tests.plugin

--- a/tests/README.md
+++ b/tests/README.md
@@ -10,7 +10,7 @@ Unit tests use the [pytest](https://docs.pytest.org/en/latest/index.html) testin
 
 ## Useful commands
 
-Run tests including slow tests:
+Run unit tests including slow tests:
 ```pytest --run-slow```
 
 Run tests until first failure:
@@ -30,3 +30,12 @@ Run with a different random-seed (by default fixed to 42):
 ```pytest --randomly-seed=123```
 
 This also randomizes the order of execution of tests.
+
+# Integration tests
+Run integration tests.
+1. Setup environment:
+```docker-compose up -d```
+2. Run the tests :
+```pytest --run-integration tests/integration_tests```
+3. Clean up:
+```docker-compose down```

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,9 @@ from mindsdb_native.libs.controllers.predictor import Predictor
 from mindsdb_native.config import CONFIG
 
 
+pytest_plugins = ("plugin",)
+
+
 @pytest.fixture(autouse=True)
 def config(monkeypatch):
     CONFIG.CHECK_FOR_UPDATES = False

--- a/tests/integration_tests/data_sources/test_clickhouse_ds.py
+++ b/tests/integration_tests/data_sources/test_clickhouse_ds.py
@@ -1,8 +1,10 @@
+import pytest
 import requests
 from mindsdb_native import Predictor
 from mindsdb_native.libs.data_sources.clickhouse_ds import ClickhouseDS
 
 
+@pytest.mark.integration
 def test_clickhouse_ds():
     HOST = 'localhost'
     PORT = 8123

--- a/tests/integration_tests/data_sources/test_maria_ds.py
+++ b/tests/integration_tests/data_sources/test_maria_ds.py
@@ -1,3 +1,4 @@
+import pytest
 import mysql.connector
 import datetime
 import logging
@@ -6,6 +7,7 @@ from mindsdb_native.libs.constants.mindsdb import DATA_TYPES, DATA_SUBTYPES
 from mindsdb_native import MariaDS
 
 
+@pytest.mark.integration
 def test_maria_ds():
     HOST = 'localhost'
     USER = 'root'

--- a/tests/integration_tests/data_sources/test_mysql_ds.py
+++ b/tests/integration_tests/data_sources/test_mysql_ds.py
@@ -1,9 +1,11 @@
+import pytest
 import mysql.connector
 import logging
 from mindsdb_native import Predictor
 from mindsdb_native.libs.data_sources.mysql_ds import MySqlDS
 
 
+@pytest.mark.integration
 def test_mysql_ds():
     HOST = 'localhost'
     USER = 'root'

--- a/tests/integration_tests/data_sources/test_postgres_ds.py
+++ b/tests/integration_tests/data_sources/test_postgres_ds.py
@@ -1,3 +1,4 @@
+import pytest
 import datetime
 import logging
 import pg8000
@@ -5,6 +6,7 @@ from mindsdb_native import Predictor
 from mindsdb_native.libs.data_sources.postgres_ds import PostgresDS
 
 
+@pytest.mark.integration
 def test_postgres_ds():
     HOST = 'localhost'
     USER = 'postgres'

--- a/tests/plugin.py
+++ b/tests/plugin.py
@@ -1,19 +1,36 @@
+"""This file allows to override pytest behavior,
+add new command-line options and test markers."""
+
 import pytest
 
 
 def pytest_addoption(parser):
     parser.addoption(
-        "--runslow", action="store_true", default=False, help="run slow tests",
+        "--run-slow", action="store_true", default=False, help="run slow tests",
+    )
+
+    parser.addoption(
+        "--run-integration", action="store_true", default=False, help="run integration tests",
     )
 
 
 def pytest_configure(config):
+    if config.getoption("randomly_seed") == 'default':
+        config.option.randomly_seed = 42
+
     config.addinivalue_line("markers", "slow: mark test as slow to run")
+    config.addinivalue_line("markers", "integration: mark test as integration, only runs with --run-integration provided")
 
 
 def pytest_collection_modifyitems(config, items):
-    if not config.getoption("--runslow"):
-        skip_slow = pytest.mark.skip(reason="need --runslow option to run")
+    skip_marks = ['slow', 'integration']
+
+    for mark in skip_marks:
+        mark_option = f'--run-{mark}'
+        if config.getoption(mark_option):
+            continue
+
+        skip = pytest.mark.skip(reason=f"need --run-{mark} option to run")
         for item in items:
-            if "slow" in item.keywords:
-                item.add_marker(skip_slow)
+            if mark in item.keywords:
+                item.add_marker(skip)

--- a/tests/unit_tests/libs/controllers/test_predictor.py
+++ b/tests/unit_tests/libs/controllers/test_predictor.py
@@ -13,7 +13,7 @@ from mindsdb_native.libs.controllers.predictor import Predictor
 from mindsdb_native.libs.data_sources.file_ds import FileDS
 from mindsdb_native.libs.constants.mindsdb import DATA_TYPES, DATA_SUBTYPES
 
-from tests.unit_tests.utils import (test_column_types,
+from unit_tests.utils import (test_column_types,
                                     generate_value_cols,
                                     generate_timeseries_labels,
                                     generate_log_labels,

--- a/tests/unit_tests/libs/phases/data_analyzer/test_data_analyzer.py
+++ b/tests/unit_tests/libs/phases/data_analyzer/test_data_analyzer.py
@@ -7,7 +7,7 @@ import pandas as pd
 
 from mindsdb_native.libs.data_types.transaction_data import TransactionData
 from mindsdb_native.libs.phases.data_analyzer.data_analyzer import DataAnalyzer
-from tests.unit_tests.utils import test_column_types
+from unit_tests.utils import test_column_types
 
 
 class TestDataAnalyzer:

--- a/tests/unit_tests/libs/phases/type_deductor/test_type_deductor.py
+++ b/tests/unit_tests/libs/phases/type_deductor/test_type_deductor.py
@@ -8,7 +8,7 @@ import pandas as pd
 from mindsdb_native.libs.constants.mindsdb import DATA_TYPES, DATA_SUBTYPES
 from mindsdb_native.libs.data_types.transaction_data import TransactionData
 from mindsdb_native.libs.phases.type_deductor.type_deductor import TypeDeductor
-from tests.unit_tests.utils import test_column_types
+from unit_tests.utils import test_column_types
 
 
 class TestTypeDeductor:


### PR DESCRIPTION
Now working with tests should be easier: doesn't matter where you run the `pytest` command from, the plugin will correctly load, random seed will correctly be set. Also things are more organized and everything related to tests is in `tests` dir.

@George3d6 encountered an issue where pytest couldn't load the custom plugin `tests/plugin.py`. Turned out tests only worked if the installation was done in dev mode `pip install -e .`.  We absolutely need people with non-dev installations to be able to run the tests too.

The problem was that running the `pytest` from command-line doesn't add the local directory to `PYTHONPATH`, so pytest couldn't find the import path. `pip install -e .` does add the local dir, which is why the issue was overlooked. 
Solution: top-level `conftest.py` defines the `PYTHONPATH`, so just putting it correctly solves the issue.

* `conftest.py` moved to tests. 
* `plugin` import moved to `conftest.py`.
* No more `pytest.ini`.
* Random-seed setting moved to `plugin`. It used to work only if you called pytest from the same dir as `pytest.ini`, now it works from any dir.
* `tests` are now in `PYTHONPATH` when running tests, as one would expect.
* `--runslow` renamed to `--run-slow` 
* Integration tests can be run by providing `--run-integration` option.