### PR TITLE
Cleanup for tests, transaction output types and explanation

### DIFF
--- a/mindsdb_native/libs/controllers/transaction.py
+++ b/mindsdb_native/libs/controllers/transaction.py
@@ -294,8 +294,8 @@ class Transaction:
                     input_confidence[predicted_col][nulled_col_name] = round(confidence_variation,3)
                     extra_insights[predicted_col]['if_missing'].append({nulled_col_name: nulled_out_predicted_value})
 
-            self.output_data.input_confidence = input_confidence
-            self.output_data.extra_insights = extra_insights
+            self.output_data._input_confidence = input_confidence
+            self.output_data._extra_insights = extra_insights
 
     def run(self):
         if self.lmd['type'] == TRANSACTION_BAD_QUERY:

--- a/mindsdb_native/libs/data_types/transaction_output_data.py
+++ b/mindsdb_native/libs/data_types/transaction_output_data.py
@@ -12,20 +12,20 @@ class TrainTransactionOutputData():
 
 class PredictTransactionOutputData():
     def __init__(self, transaction, data):
-        self.data = data
-        self.transaction = transaction
-        self.input_confidence = None
-        self.extra_insights = None
+        self._data = data
+        self._transaction = transaction
+        self._input_confidence = None
+        self._extra_insights = None
 
     def __iter__(self):
-        for i, value in enumerate(self.data[self.transaction.lmd['columns'][0]]):
+        for i, value in enumerate(self._data[self._transaction.lmd['columns'][0]]):
             yield TransactionOutputRow(self, i)
 
     def __getitem__(self, item):
         return TransactionOutputRow(self, item)
 
     def __str__(self):
-        return str(self.data)
+        return str(self._data)
 
     def __len__(self):
-        return len(self.data[self.transaction.lmd['columns'][0]])
+        return len(self._data[self._transaction.lmd['columns'][0]])

--- a/mindsdb_native/libs/data_types/transaction_output_row.py
+++ b/mindsdb_native/libs/data_types/transaction_output_row.py
@@ -19,27 +19,28 @@ def get_important_missing_cols(lmd, prediction_row, pred_col):
 
 class TransactionOutputRow:
     def __init__(self, transaction_output, row_index):
-        self.transaction_output = transaction_output
-        self.predict_columns = self.transaction_output.transaction.lmd['predict_columns']
-        self.row_index = row_index
-        self.col_stats = self.transaction_output.transaction.lmd['stats_v2']
-        self.data = self.transaction_output.data
+        self._transaction_output = transaction_output
+        self._predict_columns = self._transaction_output._transaction.lmd['predict_columns']
+        self._row_index = row_index
+        self._col_stats = self._transaction_output._transaction.lmd['stats_v2']
+        self._data = self._transaction_output._data
         self.explanation = self.explain()
 
     def __getitem__(self, item):
-        return self.data[item][self.row_index]
+        return self._data[item][self._row_index]
 
     def __contains__(self, item):
-        return item in self.data.keys()
+        return item in self._data.keys()
 
     def explain(self):
         answers = {}
-        for pred_col in self.predict_columns:
+        for pred_col in self._predict_columns:
             answers[pred_col] = {}
 
-            prediction_row = {col: self.data[col][self.row_index] for col in self.data.keys()}
+            prediction_row = {col: self._data[col][self._row_index] for col in self._data.keys()}
 
             answers[pred_col]['predicted_value'] = prediction_row[pred_col]
+
 
             if f'{pred_col}_model_confidence' in prediction_row:
                 answers[pred_col]['confidence'] = round((prediction_row[f'{pred_col}_model_confidence'] * 3 + prediction_row[f'{pred_col}_confidence'] * 1)/4, 4)
@@ -56,47 +57,50 @@ class TransactionOutputRow:
             if answers[pred_col]['confidence'] < 0.2:
                 quality = 'not confident'
 
-            answers[pred_col] = {
-                'prediction_quality': quality
-            }
+            answers[pred_col]['prediction_quality'] = quality
 
-            if self.col_stats[pred_col]['typing']['data_type'] in (DATA_TYPES.NUMERIC, DATA_TYPES.DATE):
+            if self._col_stats[pred_col]['typing']['data_type'] in (DATA_TYPES.NUMERIC, DATA_TYPES.DATE):
                 if f'{pred_col}_confidence_range' in prediction_row:
                     answers[pred_col]['confidence_interval'] = prediction_row[f'{pred_col}_confidence_range']
 
-            important_missing_cols = get_important_missing_cols(self.transaction_output.transaction.lmd, prediction_row, pred_col)
+            important_missing_cols = get_important_missing_cols(self._transaction_output._transaction.lmd, prediction_row, pred_col)
             answers[pred_col]['important_missing_information'] = important_missing_cols
 
-            if self.transaction_output.input_confidence is not None:
-                answers[pred_col]['confidence_composition'] = {k:v for (k,v) in self.transaction_output.input_confidence[pred_col].items() if v > 0}
+            if self._transaction_output._input_confidence is not None:
+                answers[pred_col]['confidence_composition'] = {k:v for (k,v) in self._transaction_output._input_confidence[pred_col].items() if v > 0}
 
-            if self.transaction_output.extra_insights is not None:
-                answers[pred_col]['extra_insights'] = self.transaction_output.extra_insights[pred_col]
+            if self._transaction_output._extra_insights is not None:
+                answers[pred_col]['extra_insights'] = self._transaction_output._extra_insights[pred_col]
 
         return answers
 
 
-    def epitomize(self):
+    def summarize(self):
         answers = self.explain()
         simple_answers = []
 
         for pred_col in answers:
-            confidence = answers[pred_col]['confidence']
+            confidence = round(answers[pred_col]['confidence']*100,2)
             value = answers[pred_col]['predicted_value']
-            simple_col_answer = f'We are {confidence}% confident the value of "{pred_col}" is {value}'
+            if 'confidence_interval' in answers[pred_col]:
+                start = answers[pred_col]['confidence_interval'][0]
+                end = answers[pred_col]['confidence_interval'][1]
+                simple_col_answer = f'We are {confidence}% confident the value of "{pred_col}" is between {start} and {end}'
+            else:
+                simple_col_answer = f'We are {confidence}% confident the value of "{pred_col}" is {value}'
             simple_answers.append(simple_col_answer)
 
         return '* ' + '\n* '.join(simple_answers)
 
     def __str__(self):
-        return str(self.epitomize())
+        return str(self.summarize())
 
     def as_dict(self):
-        return {key: self.data[key][self.row_index] for key in list(self.data.keys()) if not key.startswith('model_')}
+        return {key: self._data[key][self._row_index] for key in list(self._data.keys()) if not key.startswith('model_')}
 
     def as_list(self):
         #Note that here we will not output the confidence columns
-        return [self.data[col][self.row_index] for col in list(self.data.keys()) if not col.startswith('model_')]
+        return [self._data[col][self._row_index] for col in list(self._data.keys()) if not col.startswith('model_')]
 
     def raw_predictions(self):
-        return {key: self.data[key][self.row_index] for key in list(self.data.keys()) if key.startswith('model_')}
+        return {key: self._data[key][self._row_index] for key in list(self._data.keys()) if key.startswith('model_')}

--- a/mindsdb_native/libs/data_types/transaction_output_row.py
+++ b/mindsdb_native/libs/data_types/transaction_output_row.py
@@ -56,25 +56,22 @@ class TransactionOutputRow:
             if answers[pred_col]['confidence'] < 0.2:
                 quality = 'not confident'
 
-            answers[pred_col]['explanation'] = {
+            answers[pred_col] = {
                 'prediction_quality': quality
             }
 
             if self.col_stats[pred_col]['typing']['data_type'] in (DATA_TYPES.NUMERIC, DATA_TYPES.DATE):
                 if f'{pred_col}_confidence_range' in prediction_row:
-                    answers[pred_col]['explanation']['confidence_interval'] = prediction_row[f'{pred_col}_confidence_range']
+                    answers[pred_col]['confidence_interval'] = prediction_row[f'{pred_col}_confidence_range']
 
             important_missing_cols = get_important_missing_cols(self.transaction_output.transaction.lmd, prediction_row, pred_col)
-            answers[pred_col]['explanation']['important_missing_information'] = important_missing_cols
+            answers[pred_col]['important_missing_information'] = important_missing_cols
 
             if self.transaction_output.input_confidence is not None:
-                answers[pred_col]['explanation']['confidence_composition'] = {k:v for (k,v) in self.transaction_output.input_confidence[pred_col].items() if v > 0}
+                answers[pred_col]['confidence_composition'] = {k:v for (k,v) in self.transaction_output.input_confidence[pred_col].items() if v > 0}
 
             if self.transaction_output.extra_insights is not None:
-                answers[pred_col]['explanation']['extra_insights'] = self.transaction_output.extra_insights[pred_col]
-
-            for k in answers[pred_col]['explanation']:
-                answers[pred_col][k] = answers[pred_col]['explanation'][k]
+                answers[pred_col]['extra_insights'] = self.transaction_output.extra_insights[pred_col]
 
         return answers
 

--- a/tests/unit_tests/libs/controllers/test_predictor.py
+++ b/tests/unit_tests/libs/controllers/test_predictor.py
@@ -106,8 +106,8 @@ class TestPredictor:
         result = mdb.predict(when={"numeric_x": 10, 'categorical_x': 1})
         explanation_new = result[0].explanation['numeric_y']
         assert isinstance(explanation_new['predicted_value'], int)
-        assert explanation_new['confidence_interval'][0] < explanation_new['predicted_value'] < explanation_new['confidence_interval'][1]
-        assert explanation_new['confidence'] >= 0.8
+        assert isinstance(explanation_new['confidence_interval'],list)
+        assert isinstance(explanation_new['confidence_interval'][0],int)
         assert isinstance(explanation_new['important_missing_information'], list)
         assert isinstance(explanation_new['prediction_quality'], str)
 

--- a/tests/unit_tests/libs/controllers/test_predictor.py
+++ b/tests/unit_tests/libs/controllers/test_predictor.py
@@ -100,7 +100,7 @@ class TestPredictor:
         mdb.learn(
             from_data=input_dataframe,
             to_predict='numeric_y',
-            stop_training_in_x_seconds=15
+            stop_training_in_x_seconds=1
         )
 
         result = mdb.predict(when={"numeric_x": 10, 'categorical_x': 1})

--- a/tests/unit_tests/libs/controllers/test_predictor.py
+++ b/tests/unit_tests/libs/controllers/test_predictor.py
@@ -338,7 +338,6 @@ class TestPredictor:
             assert hasattr(prediction, 'data')
             assert hasattr(prediction, 'extra_insights')
             assert hasattr(prediction, 'transaction')
-            assert hasattr(prediction[0], 'explanation')
             assert hasattr(prediction[0], 'data')
             assert prediction[0].predict_columns[0] == 'rental_price'
 

--- a/tests/unit_tests/libs/controllers/test_predictor.py
+++ b/tests/unit_tests/libs/controllers/test_predictor.py
@@ -100,16 +100,18 @@ class TestPredictor:
         mdb.learn(
             from_data=input_dataframe,
             to_predict='numeric_y',
-            stop_training_in_x_seconds=1
+            stop_training_in_x_seconds=15
         )
 
         result = mdb.predict(when={"numeric_x": 10, 'categorical_x': 1})
         explanation_new = result[0].explanation['numeric_y']
-        assert explanation_new['predicted_value'] is not None
-        assert explanation_new['confidence_interval']
+        assert isinstance(explanation_new['predicted_value'], int)
+        assert explanation_new['confidence_interval'][0] < explanation_new['predicted_value'] < explanation_new['confidence_interval'][1]
         assert explanation_new['confidence'] >= 0.8
-        assert explanation_new['important_missing_information'] == []
-        assert explanation_new['prediction_quality'] == 'very confident'
+        assert isinstance(explanation_new['important_missing_information'], list)
+        assert isinstance(explanation_new['prediction_quality'], str)
+
+        assert len(str(result[0])) > 20
 
 
     @pytest.mark.skip(reason="Causes error in probabilistic validator")
@@ -334,36 +336,21 @@ class TestPredictor:
                   stop_training_in_x_seconds=1,
                   use_gpu=use_gpu)
 
-        def assert_prediction_interface(prediction):
-            assert hasattr(prediction, 'data')
-            assert hasattr(prediction, 'extra_insights')
-            assert hasattr(prediction, 'transaction')
-            assert hasattr(prediction[0], 'data')
-            assert prediction[0].predict_columns[0] == 'rental_price'
-
-            for item in prediction:
-                # Assert __str__ works
-                print(item)
-
-            print(prediction[0].as_dict())
-            print(prediction[0].as_list())
-            print(prediction[0]['rental_price_confidence'])
-            print(type(prediction[0]['rental_price_confidence']))
-
-            print(prediction[0].explanation)
-            print(prediction[0].raw_predictions())
+        def assert_prediction_interface(predictions):
+            for prediction in predictions:
+                assert hasattr(prediction, 'explanation')
 
         test_results = mdb.test(
             when_data="https://s3.eu-west-2.amazonaws.com/mindsdb-example-data/home_rentals.csv",
             accuracy_score_functions=r2_score, predict_args={'use_gpu': use_gpu})
         assert test_results['rental_price_accuracy'] >= 0.8
 
-        prediction = mdb.predict(
+        predictions = mdb.predict(
             when_data="https://s3.eu-west-2.amazonaws.com/mindsdb-example-data/home_rentals.csv",
             use_gpu=use_gpu)
-        assert_prediction_interface(prediction)
-        prediction = mdb.predict(when={'sqft': 300}, use_gpu=use_gpu)
-        assert_prediction_interface(prediction)
+        assert_prediction_interface(predictions)
+        predictions = mdb.predict(when={'sqft': 300}, use_gpu=use_gpu)
+        assert_prediction_interface(predictions)
 
         amd = F.get_model_data('home_rentals_price')
 


### PR DESCRIPTION
* Made the members of `PredictTransactionOutputData` and `TransactionOutputRow` that we wouldn't necessarily want to expose to the user "private"
* No longer testing for the existence of these members as part of testing the interface
* Remove redundant information from the `.explain()` function (as a result it will also be removed from `explanation`)
* Removed redundant checks and checks without explicit assertions from the `.explanation` tests and changed to checks for existence + python type correctness
* Renamed `epitomize` to `summarize` and made it print the confidence range instead of the predicted values for numbers