### PR TITLE
Fix OSX tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,9 +54,9 @@ install:
   - if [ "$TRAVIS_OS_NAME" = "windows" ]; then travis_wait 15 pip install --no-cache-dir -e .; fi
   - if [ "$TRAVIS_OS_NAME" = "windows" ]; then travis_wait 15 pip install --no-cache-dir -r requirements_test.txt; fi
   - if [ "$TRAVIS_OS_NAME" = "windows" ]; then travis_wait 15 pip install --no-cache-dir -r optional_requirements_extra_data_sources.txt; fi
-  - if [ "$TRAVIS_OS_NAME" != "windows" ]; then travis_wait 15 pip3 install --no-cache-dir -e .; sleep 10s; fi
-  - if [ "$TRAVIS_OS_NAME" != "windows" ]; then travis_wait 15 pip3 install --no-cache-dir -r requirements_test.txt; fi
-  - if [ "$TRAVIS_OS_NAME" != "windows" ]; then travis_wait 15 pip3 install --no-cache-dir -r optional_requirements_extra_data_sources.txt; fi
+  - if [ "$TRAVIS_OS_NAME" != "windows" ]; then travis_wait 15 pip3 install --user --no-cache-dir -e .; sleep 10s; fi
+  - if [ "$TRAVIS_OS_NAME" != "windows" ]; then travis_wait 15 pip3 install --user --no-cache-dir -r requirements_test.txt; fi
+  - if [ "$TRAVIS_OS_NAME" != "windows" ]; then travis_wait 15 pip3 install --user --no-cache-dir -r optional_requirements_extra_data_sources.txt; fi
 # run tests
 before_script:
   # Travis doesn't support docker on OSX and it doesn't work on Windows too

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,16 +54,21 @@ install:
   - if [ "$TRAVIS_OS_NAME" = "windows" ]; then travis_wait 15 pip install --no-cache-dir -e .; fi
   - if [ "$TRAVIS_OS_NAME" = "windows" ]; then travis_wait 15 pip install --no-cache-dir -r requirements_test.txt; fi
   - if [ "$TRAVIS_OS_NAME" = "windows" ]; then travis_wait 15 pip install --no-cache-dir -r optional_requirements_extra_data_sources.txt; fi
-  - if [ "$TRAVIS_OS_NAME" != "windows" ]; then travis_wait 15 pip3 install --user --no-cache-dir -e .; sleep 10s; fi
-  - if [ "$TRAVIS_OS_NAME" != "windows" ]; then travis_wait 15 pip3 install --user --no-cache-dir -r requirements_test.txt; fi
-  - if [ "$TRAVIS_OS_NAME" != "windows" ]; then travis_wait 15 pip3 install --user --no-cache-dir -r optional_requirements_extra_data_sources.txt; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then travis_wait 15 pip3 install --user --no-cache-dir -e .; sleep 10s; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then travis_wait 15 pip3 install --user --no-cache-dir -r requirements_test.txt; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then travis_wait 15 pip3 install --user --no-cache-dir -r optional_requirements_extra_data_sources.txt; fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then travis_wait 15 pip3 install --no-cache-dir -e .; sleep 10s; fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then travis_wait 15 pip3 install --no-cache-dir -r requirements_test.txt; fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then travis_wait 15 pip3 install --no-cache-dir -r optional_requirements_extra_data_sources.txt; fi
+
 # run tests
 before_script:
   # Travis doesn't support docker on OSX and it doesn't work on Windows too
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then travis_wait 20  docker-compose up -d; fi
 script:
   # Unit tests
-  - travis_wait 15 pytest --run-slow --durations=20 tests/unit_tests
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then travis_wait 15 python3 - m pytest --run-slow --durations=20 tests/unit_tests; fi
+  - if [ "$TRAVIS_OS_NAME" != "osx" ]; then travis_wait 15 pytest --run-slow --durations=20 tests/unit_tests; fi
   # Integration tests, require docker so only run on linux
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then travis_wait 15 pytest --run-integration tests/integration_tests ; fi
   - pip install flake8

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ matrix:
     - name: "Python 3.7.2 on OSX"
       os: osx
       language: shell
-      dist: xcode10.2
+      dist: xcode12
       env:
         BADGE=osx
 
@@ -54,7 +54,7 @@ install:
   - if [ "$TRAVIS_OS_NAME" = "windows" ]; then travis_wait 15 pip install --no-cache-dir -e .; fi
   - if [ "$TRAVIS_OS_NAME" = "windows" ]; then travis_wait 15 pip install --no-cache-dir -r requirements_test.txt; fi
   - if [ "$TRAVIS_OS_NAME" = "windows" ]; then travis_wait 15 pip install --no-cache-dir -r optional_requirements_extra_data_sources.txt; fi
-  - if [ "$TRAVIS_OS_NAME" != "windows" ]; then travis_wait 15 pip3 install --no-cache-dir -e .; fi
+  - if [ "$TRAVIS_OS_NAME" != "windows" ]; then travis_wait 15 pip3 install --no-cache-dir -e .; sleep 10s; fi
   - if [ "$TRAVIS_OS_NAME" != "windows" ]; then travis_wait 15 pip3 install --no-cache-dir -r requirements_test.txt; fi
   - if [ "$TRAVIS_OS_NAME" != "windows" ]; then travis_wait 15 pip3 install --no-cache-dir -r optional_requirements_extra_data_sources.txt; fi
 # run tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ install:
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then travis_wait 15 pip3 install --user --no-cache-dir -e .; sleep 10s; fi
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then travis_wait 15 pip3 install --user --no-cache-dir -r requirements_test.txt; fi
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then travis_wait 15 pip3 install --user --no-cache-dir -r optional_requirements_extra_data_sources.txt; fi
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then travis_wait 15 pip3 install --no-cache-dir -e .; sleep 10s; fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then travis_wait 15 pip3 install --no-cache-dir -e .; fi
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then travis_wait 15 pip3 install --no-cache-dir -r requirements_test.txt; fi
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then travis_wait 15 pip3 install --no-cache-dir -r optional_requirements_extra_data_sources.txt; fi
 


### PR DESCRIPTION
* Upgraded to xcode12

* Installing everything as `--user`

* Consequently, running `pytest` with `python3 -m` since it's only installed for the user

* Added short sleep after the mindsdb_native installation for OSX

Honestly, it might be that one or multiple of these changes are *not* required, I'm only ~100% certain the `--user` one is, but testing with travis is slow and hard and prone to error because traivs sometimes "naturally" fails or delays builds by 5-10 minutes.

So, unless anyone wants to have fun experimenting, this should be merged as is for now.