### PR TITLE
Remove unneeded random seed setting is tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,12 +20,6 @@ def config(tmp_path):
     shutil.rmtree(CONFIG.MINDSDB_STORAGE_PATH)
 
 
-@pytest.fixture(autouse=True)
-def clear_mindsdb_storage():
-    yield None
-    # Execute after each test
-
-
 @pytest.fixture()
 def logger():
     return MindsdbLogger(log_level=logging.DEBUG, uuid='test')

--- a/tests/unit_tests/utils.py
+++ b/tests/unit_tests/utils.py
@@ -6,8 +6,6 @@ from unittest import mock
 from math import log
 from mindsdb_native.libs.constants.mindsdb import DATA_TYPES, DATA_SUBTYPES
 
-random.seed(0)
-
 test_column_types = {
     'numeric_int': (DATA_TYPES.NUMERIC, DATA_SUBTYPES.INT),
     'numeric_float': (DATA_TYPES.NUMERIC, DATA_SUBTYPES.FLOAT),


### PR DESCRIPTION
It's already fixed by pytest-randomly plugin, so we don't need to fix it in code