### PR TITLE
Breakpoints

### DIFF
--- a/mindsdb_native/libs/controllers/functional.py
+++ b/mindsdb_native/libs/controllers/functional.py
@@ -55,7 +55,8 @@ def analyse_dataset(from_data, sample_settings=None, logger=log):
         force_categorical_encoding = [],
         handle_text_as_categorical = False,
         data_types = {},
-        data_subtypes = {}
+        data_subtypes = {},
+        breakpoint = None
     )
 
     tx = Transaction(

--- a/mindsdb_native/libs/controllers/predictor.py
+++ b/mindsdb_native/libs/controllers/predictor.py
@@ -67,6 +67,7 @@ class Predictor:
         self.name = name
         self.uuid = str(uuid.uuid1())
         self.log = MindsdbLogger(log_level=log_level, uuid=self.uuid)
+        self.breakpoint = None
 
         if CONFIG.CHECK_FOR_UPDATES:
             check_for_updates()
@@ -228,7 +229,8 @@ class Predictor:
             force_categorical_encoding = unstable_parameters_dict.get('force_categorical_encoding', []),
             handle_foreign_keys = unstable_parameters_dict.get('handle_foreign_keys', False),
             handle_text_as_categorical = unstable_parameters_dict.get('handle_text_as_categorical', False),
-            use_selfaware_model = unstable_parameters_dict.get('use_selfaware_model', True)
+            use_selfaware_model = unstable_parameters_dict.get('use_selfaware_model', True),
+            breakpoint=self.breakpoint
         )
 
         if rebuild_model is False:
@@ -337,7 +339,8 @@ class Predictor:
             use_gpu = use_gpu,
             data_preparation = {},
             run_confidence_variation_analysis = run_confidence_variation_analysis,
-            force_disable_cache = unstable_parameters_dict.get('force_disable_cache', disable_lightwood_transform_cache)
+            force_disable_cache = unstable_parameters_dict.get('force_disable_cache', disable_lightwood_transform_cache),
+            breakpoint=self.breakpoint
         )
 
         transaction = Transaction(session=self,

--- a/mindsdb_native/libs/controllers/transaction.py
+++ b/mindsdb_native/libs/controllers/transaction.py
@@ -51,7 +51,6 @@ class Transaction:
         # variables that can be persisted
 
         self.log = logger
-
         self.run()
 
     def load_metadata(self):
@@ -114,10 +113,13 @@ class Transaction:
         """
         Loads the module and runs it
         """
+        if self.lmd['breakpoint'] == module_name:
+            sys.exit(0)
 
         self.lmd['is_active'] = True
+        self.lmd['phase'] = module_name
         module_path = convert_cammelcase_to_snake_string(module_name)
-        module_full_path = 'mindsdb_native.libs.phases.{module_path}.{module_path}'.format(module_path=module_path)
+        module_full_path = f'mindsdb_native.libs.phases.{module_path}.{module_path}'
         try:
             main_module = importlib.import_module(module_full_path)
             module = getattr(main_module, module_name)
@@ -127,6 +129,7 @@ class Transaction:
             self.log.error(error)
             raise
         finally:
+            self.lmd['phase'] = module_name
             self.lmd['is_active'] = False
 
     def _execute_analyze(self):

--- a/mindsdb_native/libs/data_types/data_source.py
+++ b/mindsdb_native/libs/data_types/data_source.py
@@ -58,6 +58,9 @@ class DataSource:
         cols = [col if col not in self._col_map else self._col_map[col] for col in column_list]
         self._df = self._df.drop(columns=cols)
 
+    def __getstate__(self): return self.__dict__
+    def __setstate__(self, d): self.__dict__.update(d)
+
     def __getattr__(self, item):
         """
         Map all other functions to the DataFrame
@@ -65,7 +68,8 @@ class DataSource:
         :param item: the attribute to get
         :return: the dataframe attribute
         """
-
+        if item.startswith('__') and item.endswith('__'):
+            raise AttributeError
         return getattr(self._df, item)
 
 


### PR DESCRIPTION
* Added a guard against incorrect __getitem__ access causing pickling error with data sources
* Added breakpoints (just set `.breakpoint` on a predictor object and name is the same as the phrase you want to stop at)
* Added `phase` property set by `_call_phase_module` to potentially inform the GUI about the phase currently running.