### PR TITLE
Changes to allow for easier testing

### DIFF
--- a/mindsdb_native/libs/controllers/predictor.py
+++ b/mindsdb_native/libs/controllers/predictor.py
@@ -243,7 +243,7 @@ class Predictor:
                 if old_hmd['from_data'] is not None:
                     heavy_transaction_metadata['from_data'] = old_hmd['from_data']
 
-            self.transaction = transaction = LearnTransaction(session=self,
+            self.transaction = LearnTransaction(session=self,
                         light_transaction_metadata=light_transaction_metadata,
                         heavy_transaction_metadata=heavy_transaction_metadata,
                         logger=self.log)

--- a/mindsdb_native/libs/controllers/predictor.py
+++ b/mindsdb_native/libs/controllers/predictor.py
@@ -66,6 +66,7 @@ class Predictor:
         self.uuid = str(uuid.uuid1())
         self.log = MindsdbLogger(log_level=log_level, uuid=self.uuid)
         self.breakpoint = None
+        self.transaction = None
 
         if CONFIG.CHECK_FOR_UPDATES:
             check_for_updates()
@@ -242,12 +243,10 @@ class Predictor:
                 if old_hmd['from_data'] is not None:
                     heavy_transaction_metadata['from_data'] = old_hmd['from_data']
 
-            transaction = LearnTransaction(session=self,
+            self.transaction = transaction = LearnTransaction(session=self,
                         light_transaction_metadata=light_transaction_metadata,
                         heavy_transaction_metadata=heavy_transaction_metadata,
                         logger=self.log)
-
-            return transaction.input_data.validation_df
             
 
     def test(self, when_data, accuracy_score_functions, score_using='predicted_value', predict_args=None):
@@ -341,7 +340,7 @@ class Predictor:
                 breakpoint=self.breakpoint
             )
 
-            transaction = PredictTransaction(session=self,
+            self.transaction = PredictTransaction(session=self,
                                     light_transaction_metadata=light_transaction_metadata,
                                     heavy_transaction_metadata=heavy_transaction_metadata)
-            return transaction.output_data
+            return self.transaction.output_data

--- a/mindsdb_native/libs/controllers/predictor.py
+++ b/mindsdb_native/libs/controllers/predictor.py
@@ -246,6 +246,7 @@ class Predictor:
                         light_transaction_metadata=light_transaction_metadata,
                         heavy_transaction_metadata=heavy_transaction_metadata,
                         logger=self.log)
+            
 
     def test(self, when_data, accuracy_score_functions, score_using='predicted_value', predict_args=None):
         """
@@ -272,7 +273,13 @@ class Predictor:
                 else:
                     acc_f = accuracy_score_functions
 
-                accuracy_dict[f'{col}_accuracy'] = acc_f([x[f'__observed_{col}'] for x in predictions], [x.explanation[col][score_using] for x in predictions])
+                if score_using is None:
+                    predicted = [x.explanation[col] for x in predictions]
+                else:
+                    predicted = [x.explanation[col][score_using] for x in predictions]
+                    
+                real = [x[f'__observed_{col}'] for x in predictions]
+                accuracy_dict[f'{col}_accuracy'] = acc_f(real, predicted)
 
             return accuracy_dict
 

--- a/mindsdb_native/libs/controllers/predictor.py
+++ b/mindsdb_native/libs/controllers/predictor.py
@@ -242,10 +242,12 @@ class Predictor:
                 if old_hmd['from_data'] is not None:
                     heavy_transaction_metadata['from_data'] = old_hmd['from_data']
 
-            LearnTransaction(session=self,
+            transaction = LearnTransaction(session=self,
                         light_transaction_metadata=light_transaction_metadata,
                         heavy_transaction_metadata=heavy_transaction_metadata,
                         logger=self.log)
+
+            return transaction.input_data.validation_df
             
 
     def test(self, when_data, accuracy_score_functions, score_using='predicted_value', predict_args=None):
@@ -277,7 +279,7 @@ class Predictor:
                     predicted = [x.explanation[col] for x in predictions]
                 else:
                     predicted = [x.explanation[col][score_using] for x in predictions]
-                    
+
                 real = [x[f'__observed_{col}'] for x in predictions]
                 accuracy_dict[f'{col}_accuracy'] = acc_f(real, predicted)
 


### PR DESCRIPTION
* Changed the `test` method to allow passing the full `.explanation` property to the scoring function (in order allow for e.g. evaluating numerical ranges or evaluation based on the actual predictions + confidences)
* Change `learn` in order to return the validation dataset

Note: Not to be merged just yet, but feel free to review if you have the time.