### PR TITLE
add name to datasources

### DIFF
--- a/mindsdb_native/libs/controllers/predictor.py
+++ b/mindsdb_native/libs/controllers/predictor.py
@@ -172,7 +172,7 @@ class Predictor:
             the server doesn't handle non-file data sources at the moment, so this shouldn't prove an issue,
             once we want to support datasources such as s3 and databases for the server we need to add name as a concept (or, preferably, before that)
             """
-            data_source_name = from_data if isinstance(from_data, str) else 'Unkown'
+            data_source_name = from_ds.name()
 
             heavy_transaction_metadata = dict(
                 name=self.name,

--- a/mindsdb_native/libs/data_sources/clickhouse_ds.py
+++ b/mindsdb_native/libs/data_sources/clickhouse_ds.py
@@ -7,12 +7,14 @@ from mindsdb_native.libs.data_types.mindsdb_logger import log
 
 class ClickhouseDS(DataSource):
 
-    def _setup(self, query, host='localhost', user='default', password=None, port=8123, protocol='http'):
+    def _setup(self, query, host='localhost', user='default',
+               password=None, port=8123, protocol='http'):
+
         if protocol not in ('https', 'http'):
             raise ValueError('Unexpected protocol {}'.fomat(protocol))
 
         if ' format ' in query.lower():
-            err_msg = 'Please refrain from adding a "FROAMT" statement to the query'
+            err_msg = 'Please refrain from adding a "FORMAT" statement to the query'
             log.error(err_msg)
             raise Exception(err_msg)
         
@@ -38,3 +40,6 @@ class ClickhouseDS(DataSource):
             col_map[col] = col
 
         return df, col_map
+
+    def name(self):
+        return '{}'.format(self.__class__.__name__)

--- a/mindsdb_native/libs/data_sources/file_ds.py
+++ b/mindsdb_native/libs/data_sources/file_ds.py
@@ -1,4 +1,4 @@
-import re
+import os
 from io import BytesIO, StringIO
 import csv
 import codecs
@@ -146,13 +146,17 @@ class FileDS(DataSource):
             # No file type identified
             return data, None, dialect
 
-    def _setup(self,file, clean_rows = True, custom_parser = None):
+    def name(self):
+        return '{}: {}'.format(self.__class__.__name__, self._file_name)
+
+    def _setup(self, file, clean_rows=True, custom_parser=None):
         """
         Setup from file
         :param file: fielpath or url
-        :param clean_rows:  if you want to clean rows for strange null values
+        :param clean_rows: if you want to clean rows for strange null values
         :param custom_parser: if you want to parse the file with some custom parser
         """
+        self._file_name = os.path.basename(file)
 
         # get file data io, format and dialect
         data, fmt, dialect = self._getDataIo(file)

--- a/mindsdb_native/libs/data_sources/maria_ds.py
+++ b/mindsdb_native/libs/data_sources/maria_ds.py
@@ -9,6 +9,7 @@ class MariaDS(DataSource):
     def _setup(self, query=None, host='localhost', user='root', password='',
                database='mysql', port=3306, table=None):
 
+        self._database_name = database
         self._table_name = table
 
         if query is None:
@@ -29,7 +30,8 @@ class MariaDS(DataSource):
         return df, col_map
 
     def name(self):
-        return '{}: {}'.format(
+        return '{}: {}/{}'.format(
             self.__class__.__name__,
+            self._database_name,
             self._table_name
         )

--- a/mindsdb_native/libs/data_sources/maria_ds.py
+++ b/mindsdb_native/libs/data_sources/maria_ds.py
@@ -9,6 +9,8 @@ class MariaDS(DataSource):
     def _setup(self, query=None, host='localhost', user='root', password='',
                database='mysql', port=3306, table=None):
 
+        self._table_name = table
+
         if query is None:
             query = f'SELECT * FROM {table}'
 
@@ -25,3 +27,9 @@ class MariaDS(DataSource):
             col_map[col] = col
 
         return df, col_map
+
+    def name(self):
+        return '{}: {}'.format(
+            self.__class__.__name__,
+            self._table_name
+        )

--- a/mindsdb_native/libs/data_sources/mongodb_ds.py
+++ b/mindsdb_native/libs/data_sources/mongodb_ds.py
@@ -8,6 +8,9 @@ class MongoDS(DataSource):
     def _setup(self, collection, query=None, host='localhost', port=27017, user='admin',
                password='123', database='database'):
         
+        self._collection_name = collection
+        self._database_name = database
+
         if not isinstance(collection, str):
             raise TypeError('collection must be a str')
         
@@ -32,3 +35,10 @@ class MongoDS(DataSource):
             col_map[col] = col
 
         return df, col_map
+
+    def name(self):
+        return '{}: {}/{}'.format(
+            self.__class__.__name__,
+            self._database_name,
+            self._collection_name
+        )

--- a/mindsdb_native/libs/data_sources/ms_sql_ds.py
+++ b/mindsdb_native/libs/data_sources/ms_sql_ds.py
@@ -7,6 +7,9 @@ class MSSQLDS(DataSource):
     def _setup(self, query=None, host='localhost', user='sa', password='',
                database='master', port=1433, table=None):
 
+        self._database_name = database
+        self._table_name = table
+
         if query is None:
             query = f'SELECT * FROM {table}'
 
@@ -21,3 +24,10 @@ class MSSQLDS(DataSource):
             col_map[col] = col
 
         return df, col_map
+
+    def name(self):
+        return '{}: {}/{}'.format(
+            self.__class__.__name__,
+            self._database_name,
+            self._table_name
+        )

--- a/mindsdb_native/libs/data_sources/mysql_ds.py
+++ b/mindsdb_native/libs/data_sources/mysql_ds.py
@@ -9,6 +9,9 @@ class MySqlDS(DataSource):
     def _setup(self, query=None, host='localhost', user='root', password='',
                database='mysql', port=3306, table=None):
 
+        self._database_name = database
+        self._table_name = table
+
         if query is None:
             query = f'SELECT * FROM {table}'
 
@@ -25,3 +28,10 @@ class MySqlDS(DataSource):
             col_map[col] = col
 
         return df, col_map
+
+    def name(self):
+        return '{}: {}/{}'.format(
+            self.__class__.__name__,
+            self._database_name,
+            self._table_name
+        )

--- a/mindsdb_native/libs/data_sources/postgres_ds.py
+++ b/mindsdb_native/libs/data_sources/postgres_ds.py
@@ -11,6 +11,9 @@ class PostgresDS(DataSource):
     def _setup(self, query=None, host='localhost', user='postgres', password='',
                database='postgres', port=5432, table=None):
 
+        self._database_name = database
+        self._table_name = table
+
         if query is None:
             query = f'SELECT * FROM {table}'
 
@@ -31,3 +34,10 @@ class PostgresDS(DataSource):
             col_map[col] = col
 
         return df, col_map
+
+    def name(self):
+        return '{}: {}/{}'.format(
+            self.__class__.__name__,
+            self._database_name,
+            self._table_name
+        )

--- a/mindsdb_native/libs/data_sources/s3_ds.py
+++ b/mindsdb_native/libs/data_sources/s3_ds.py
@@ -14,6 +14,9 @@ class S3DS(DataSource):
     def _setup(self, bucket_name, file_path, access_key=None,
                secret_key=None,use_default_credentails=False):
 
+        self._bucket_name = bucket_name
+        self._file_name = os.path.basename(file_path)
+
         if access_key is not None and secret_key is not None:
             s3 = boto3.client('s3', aws_access_key_id=access_key, aws_secret_access_key=secret_key)
         elif use_default_credentails:
@@ -31,3 +34,11 @@ class S3DS(DataSource):
 
     def _cleanup(self):
         os.remove(self.tmp_file_name)
+
+
+    def name(self):
+        return '{}: {}/{}'.format(
+            self.__class__.__name__,
+            self._bucket_name,
+            self._file_name
+        )

--- a/mindsdb_native/libs/data_types/data_source.py
+++ b/mindsdb_native/libs/data_types/data_source.py
@@ -14,6 +14,9 @@ class DataSource:
         self._set_df(df, col_map)
         self._cleanup()
 
+    def name(self):
+        return 'Unknown'
+
     def _setup(self, df, **kwargs):
         col_map = {}
 

--- a/tests/integration_tests/data_sources/test_maria_ds.py
+++ b/tests/integration_tests/data_sources/test_maria_ds.py
@@ -68,6 +68,9 @@ def test_maria_ds():
 
     maria_ds = MariaDS(table='test_mindsdb', host=HOST, user=USER,
                        password=PASSWORD, database=DATABASE, port=PORT)
+
+    assert maria_ds.name() == 'MariaDS: mysql/test_mindsdb'
+
     assert (len(maria_ds._df) == 200)
 
     mdb = Predictor(name='analyse_dataset_test_predictor', log_level=logging.ERROR)

--- a/tests/integration_tests/data_sources/test_mongodb_ds.py
+++ b/tests/integration_tests/data_sources/test_mongodb_ds.py
@@ -44,6 +44,8 @@ def test_mongodb_ds():
                          password=PASSWORD,
                          database=DATABASE)
 
+    assert mongodb_ds.name() == 'MongoDS: database/test_mindsdb'
+
     assert (len(mongodb_ds._df) == 200)
 
     mdb = Predictor(name='analyse_dataset_test_predictor', log_level=logging.ERROR)

--- a/tests/integration_tests/data_sources/test_ms_sql_ds.py
+++ b/tests/integration_tests/data_sources/test_ms_sql_ds.py
@@ -27,6 +27,9 @@ def test_mssql_ds():
 
     mssql_ds = MSSQLDS(table='test_mindsdb', host=HOST, user=USER,
                        password=PASSWORD, database=DATABASE, port=PORT)
+
+    assert mssql_ds.name() == 'MSSQLDS: master/test_mindsdb'
+
     assert (len(mssql_ds._df) == 200)
 
     mdb = Predictor(name='analyse_dataset_test_predictor', log_level=logging.ERROR)

--- a/tests/integration_tests/data_sources/test_mysql_ds.py
+++ b/tests/integration_tests/data_sources/test_mysql_ds.py
@@ -29,6 +29,9 @@ def test_mysql_ds():
 
     mysql_ds = MySqlDS(table='test_mindsdb', host=HOST, user=USER,
                        password=PASSWORD, database=DATABASE, port=PORT)
+
+    assert mysql_ds.name() == 'MySqlDS: mysql/test_mindsdb'
+
     assert (len(mysql_ds._df) == 200)
 
     mdb = Predictor(name='analyse_dataset_test_predictor', log_level=logging.ERROR)

--- a/tests/integration_tests/data_sources/test_postgres_ds.py
+++ b/tests/integration_tests/data_sources/test_postgres_ds.py
@@ -30,9 +30,12 @@ def test_postgres_ds():
     con.commit()
     con.close()
 
-    mysql_ds = PostgresDS(table='test_mindsdb', host=HOST, user=USER,
+    postgres_ds = PostgresDS(table='test_mindsdb', host=HOST, user=USER,
                           password=PASSWORD, database=DBNAME, port=PORT)
-    assert (len(mysql_ds._df) == 200)
+                        
+    assert postgres_ds.name() == 'PostgresDS: postgres/test_mindsdb'
+
+    assert (len(postgres_ds._df) == 200)
 
     mdb = Predictor(name='analyse_dataset_test_predictor', log_level=logging.ERROR)
-    F.analyse_dataset(from_data=mysql_ds)
+    F.analyse_dataset(from_data=postgres_ds)


### PR DESCRIPTION
Should resolve https://github.com/mindsdb/mindsdb_gui/issues/414

`class DataSource` now has `name()` method that returns `'Unknown'` by default, and can be overridden by subclasses to return the name of the datasource. In case of databases, for example, the name is defined as `"{self.__class.__name__}: {db_name}/{table_name}"`

