### PR TITLE
consistent args order, make table a positional arg

### DIFF
--- a/mindsdb_native/libs/data_sources/clickhouse_ds.py
+++ b/mindsdb_native/libs/data_sources/clickhouse_ds.py
@@ -7,7 +7,9 @@ from mindsdb_native.libs.data_types.mindsdb_logger import log
 
 class ClickhouseDS(DataSource):
 
-    def _setup(self, query, host='localhost', user='default', password=None, port=8123, protocol='http'):
+    def _setup(self, query, host='localhost', user='default', password=None,
+               port=8123, protocol='http'):
+
         if protocol not in ('https', 'http'):
             raise ValueError('Unexpected protocol {}'.fomat(protocol))
 

--- a/mindsdb_native/libs/data_sources/maria_ds.py
+++ b/mindsdb_native/libs/data_sources/maria_ds.py
@@ -6,8 +6,8 @@ from mindsdb_native.libs.data_types.data_source import DataSource
 
 class MariaDS(DataSource):
 
-    def _setup(self, query=None, host='localhost', user='root', password='',
-               database='mysql', port=3306, table=None):
+    def _setup(self, table, query=None, database='mysql', host='localhost',
+               port=3306, user='root', password=''):
 
         if query is None:
             query = f'SELECT * FROM {table}'

--- a/mindsdb_native/libs/data_sources/mongodb_ds.py
+++ b/mindsdb_native/libs/data_sources/mongodb_ds.py
@@ -5,9 +5,9 @@ from mindsdb_native.libs.data_types.data_source import DataSource
 
 
 class MongoDS(DataSource):
-    def _setup(self, collection, query=None, host='localhost', port=27017, user='admin',
-               password='123', database='database'):
-        
+    def _setup(self, collection, query=None, database='database',
+               host='localhost', port=27017, user='admin', password='123'):
+
         if not isinstance(collection, str):
             raise TypeError('collection must be a str')
         

--- a/mindsdb_native/libs/data_sources/mongodb_ds.py
+++ b/mindsdb_native/libs/data_sources/mongodb_ds.py
@@ -11,6 +11,9 @@ class MongoDS(DataSource):
         if not isinstance(collection, str):
             raise TypeError('collection must be a str')
         
+        self._database_name = database
+        self._collection_name = collection
+
         if query is None:
             query = {}
         else:

--- a/mindsdb_native/libs/data_sources/ms_sql_ds.py
+++ b/mindsdb_native/libs/data_sources/ms_sql_ds.py
@@ -4,8 +4,8 @@ from mindsdb_native.libs.data_types.data_source import DataSource
 
 
 class MSSQLDS(DataSource):
-    def _setup(self, query=None, host='localhost', user='sa', password='',
-               database='master', port=1433, table=None):
+    def _setup(self, table, query=None, database='master', host='localhost',
+               port=1433, user='sa', password=''):
 
         if query is None:
             query = f'SELECT * FROM {table}'

--- a/mindsdb_native/libs/data_sources/mysql_ds.py
+++ b/mindsdb_native/libs/data_sources/mysql_ds.py
@@ -6,8 +6,8 @@ from mindsdb_native.libs.data_types.data_source import DataSource
 
 class MySqlDS(DataSource):
 
-    def _setup(self, query=None, host='localhost', user='root', password='',
-               database='mysql', port=3306, table=None):
+    def _setup(self, table, query=None, database='mysql', host='localhost',
+               port=3306, user='root', password=''):
 
         if query is None:
             query = f'SELECT * FROM {table}'

--- a/mindsdb_native/libs/data_sources/postgres_ds.py
+++ b/mindsdb_native/libs/data_sources/postgres_ds.py
@@ -8,8 +8,8 @@ from mindsdb_native.libs.data_types.data_source import DataSource
 
 class PostgresDS(DataSource):
 
-    def _setup(self, query=None, host='localhost', user='postgres', password='',
-               database='postgres', port=5432, table=None):
+    def _setup(self, table, query=None, database='postgres', host='localhost',
+               port=5432, user='postgres', password=''):
 
         if query is None:
             query = f'SELECT * FROM {table}'


### PR DESCRIPTION
1. Make table name a positional argument. It used to be `None` by default and the default query would be `'SELECT * from None'`
2. Make order of arguments to database datasources consistent (order: table, query, database, host, port, user, password)
