### PR TITLE
Fix data cleaner running twice

### DIFF
--- a/mindsdb_native/libs/controllers/transaction.py
+++ b/mindsdb_native/libs/controllers/transaction.py
@@ -152,10 +152,8 @@ class LearnTransaction(Transaction):
                                     input_data=self.input_data)
             self.save_metadata()
 
-            self._call_phase_module(module_name='DataCleaner')
-            self.save_metadata()
-
             self._call_phase_module(module_name='DataSplitter')
+            self.save_metadata()
 
             self._call_phase_module(module_name='DataTransformer', input_data=self.input_data)
             self.lmd['current_phase'] = MODEL_STATUS_TRAINING

--- a/tests/unit_tests/libs/controllers/test_predictor.py
+++ b/tests/unit_tests/libs/controllers/test_predictor.py
@@ -139,19 +139,21 @@ class TestPredictor:
 
     def test_ignore_columns(self):
         input_dataframe = pd.DataFrame({
-            'do_use': [1, 2, 3],
-            'ignore_this': [0, 1, 100]
+            'do_use': list(range(100)),
+            'y': list(range(100)),
+            'ignore_this': list(range(100, 0, -1))
         })
 
         predictor = Predictor(name='test')
-        transaction = predictor.learn(from_data=input_dataframe,
-                                      to_predict='do_use',
-                                      ignore_columns=['ignore_this']
+        predictor.learn(from_data=input_dataframe,
+                                      to_predict='y',
+                                      ignore_columns=['ignore_this'],
+                                      stop_training_in_x_seconds=1,
                                       )
+        transaction = predictor.transaction
 
-        assert 'do_use' in transaction.input_data.data_frame.columns
-        assert 'ignore_this' not in transaction.input_data.data_frame.columns
-
+        assert 'do_use' in transaction.input_data.train_df.columns
+        assert 'ignore_this' not in transaction.input_data.train_df.columns
 
     def test_analyze_dataset_empty_column(self):
         n_points = 100

--- a/tests/unit_tests/libs/controllers/test_predictor.py
+++ b/tests/unit_tests/libs/controllers/test_predictor.py
@@ -137,6 +137,22 @@ class TestPredictor:
             assert 'nr_warnings' in col_data
             assert not col_data['is_foreign_key']
 
+    def test_ignore_columns(self):
+        input_dataframe = pd.DataFrame({
+            'do_use': [1, 2, 3],
+            'ignore_this': [0, 1, 100]
+        })
+
+        predictor = Predictor(name='test')
+        transaction = predictor.learn(from_data=input_dataframe,
+                                      to_predict='do_use',
+                                      ignore_columns=['ignore_this']
+                                      )
+
+        assert 'do_use' in transaction.input_data.data_frame.columns
+        assert 'ignore_this' not in transaction.input_data.data_frame.columns
+
+
     def test_analyze_dataset_empty_column(self):
         n_points = 100
         input_dataframe = pd.DataFrame({

--- a/tests/unit_tests/libs/phases/data_cleaner/test_data_cleaner.py
+++ b/tests/unit_tests/libs/phases/data_cleaner/test_data_cleaner.py
@@ -1,0 +1,37 @@
+import pandas as pd
+import numpy as np
+import pytest
+
+from mindsdb_native.libs.data_types.transaction_data import TransactionData
+from mindsdb_native.libs.phases.data_cleaner.data_cleaner import DataCleaner
+
+
+class TestDataCleaner:
+    @pytest.fixture()
+    def lmd(self, transaction):
+        lmd = transaction.lmd
+        lmd['empty_columns'] = []
+        lmd['columns_to_ignore'] = []
+        lmd['predict_columns'] = []
+        return lmd
+
+    def test_ignore_columns(self, transaction, lmd):
+        data_cleaner = DataCleaner(session=transaction.session,
+                                   transaction=transaction)
+
+        input_dataframe = pd.DataFrame({
+            'do_use': [1, 2, 3],
+            'ignore_this': [0, 1, 100]
+        })
+
+        lmd['columns_to_ignore'].append('ignore_this')
+
+        input_data = TransactionData()
+        input_data.data_frame = input_dataframe
+
+        data_cleaner.transaction.input_data = input_data
+        data_cleaner.run()
+
+        assert 'do_use' in input_data.data_frame.columns
+        assert 'ignore_this' not in input_data.data_frame.columns
+


### PR DESCRIPTION
Resolves: https://github.com/mindsdb/mindsdb_native/issues/70

Turns out the problem was that DataCleaner ran twice during LearnTransaction