### PR TITLE
Raise tresholds after which sampling and lightwood cache disabling are enabled

### DIFF
--- a/mindsdb_native/libs/controllers/predictor.py
+++ b/mindsdb_native/libs/controllers/predictor.py
@@ -23,9 +23,9 @@ def _get_memory_optimizations(df):
 
     mem_usage_ratio = df_memory/total_memory
 
-    sample_for_analysis = True if mem_usage_ratio >= 0.05 else False
-    sample_for_training = True if mem_usage_ratio >= 0.15 else False
-    disable_lightwood_transform_cache = True if mem_usage_ratio >= 0.15 else False
+    sample_for_analysis = True if mem_usage_ratio >= 0.3 else False
+    sample_for_training = True if mem_usage_ratio >= 0.5 else False
+    disable_lightwood_transform_cache = True if mem_usage_ratio >= 0.3 else False
 
     return sample_for_analysis, sample_for_training, disable_lightwood_transform_cache
 
@@ -50,6 +50,7 @@ def _prepare_sample_settings(user_provided_settings,
 
     # We need the settings to be JSON serializable, so the actual function will be stored in heavy metadata
     sample_settings['sample_function'] = sample_settings['sample_function'].__name__
+
     return sample_settings, sample_function
 
 
@@ -160,6 +161,9 @@ class Predictor:
             sample_settings, sample_function = _prepare_sample_settings(sample_settings,
                                                         sample_for_analysis,
                                                         sample_for_training)
+
+            self.log.warning(f'Sample for analysis: {sample_for_analysis}')
+            self.log.warning(f'Sample for training: {sample_for_training}')
 
             if len(predict_columns) == 0:
                 error = 'You need to specify a column to predict'


### PR DESCRIPTION
Resolves: https://github.com/mindsdb/mindsdb_native/issues/68

Sampling for analysis now only enabled if the dataset is >= 30% of available RAM, same for disabling lightwood cache.
Sampling for training now only enabled if the dataset is >= 50% of available RAM.