### PR TITLE
Tests for foreign keys being ignored, ignore_columns param working

### DIFF
--- a/mindsdb_native/libs/controllers/transaction.py
+++ b/mindsdb_native/libs/controllers/transaction.py
@@ -152,10 +152,8 @@ class LearnTransaction(Transaction):
                                     input_data=self.input_data)
             self.save_metadata()
 
-            self._call_phase_module(module_name='DataCleaner')
-            self.save_metadata()
-
             self._call_phase_module(module_name='DataSplitter')
+            self.save_metadata()
 
             self._call_phase_module(module_name='DataTransformer', input_data=self.input_data)
             self.lmd['current_phase'] = MODEL_STATUS_TRAINING

--- a/mindsdb_native/libs/controllers/transaction.py
+++ b/mindsdb_native/libs/controllers/transaction.py
@@ -152,6 +152,9 @@ class LearnTransaction(Transaction):
                                     input_data=self.input_data)
             self.save_metadata()
 
+            self._call_phase_module(module_name='DataCleaner')
+            self.save_metadata()
+
             self._call_phase_module(module_name='DataSplitter')
             self.save_metadata()
 

--- a/tests/plugin.py
+++ b/tests/plugin.py
@@ -18,6 +18,9 @@ def pytest_configure(config):
     if config.getoption("randomly_seed") == 'default':
         config.option.randomly_seed = 42
 
+    if '--show-capture' not in config.invocation_params.args:
+        config.option.show_capture = False
+
     config.addinivalue_line("markers", "slow: mark test as slow to run")
     config.addinivalue_line("markers", "integration: mark test as integration, only runs with --run-integration provided")
 

--- a/tests/unit_tests/libs/controllers/test_predictor.py
+++ b/tests/unit_tests/libs/controllers/test_predictor.py
@@ -155,6 +155,39 @@ class TestPredictor:
         assert 'do_use' in transaction.input_data.train_df.columns
         assert 'ignore_this' not in transaction.input_data.train_df.columns
 
+    def test_ignore_foreign_keys(self):
+        input_dataframe = pd.DataFrame({
+            'do_use': list(range(100)),
+            'numeric_id': list(range(100)),
+            'y': list(range(100)),
+        })
+
+        predictor = Predictor(name='test')
+        predictor.learn(from_data=input_dataframe,
+                        to_predict='y',
+                        stop_training_in_x_seconds=1)
+
+        transaction = predictor.transaction
+
+        assert 'do_use' in transaction.input_data.train_df.columns
+        # Foreign key is ignored and removed from data frames
+        assert 'numeric_id' not in transaction.input_data.train_df.columns
+        assert 'numeric_id' in transaction.lmd['columns_to_ignore']
+
+        predictor = Predictor(name='test')
+        predictor.learn(from_data=input_dataframe,
+                        to_predict='y',
+                        stop_training_in_x_seconds=1,
+                        advanced_args={
+                            'handle_foreign_keys': False
+                        })
+
+        transaction = predictor.transaction
+
+        assert 'do_use' in transaction.input_data.train_df.columns
+        assert 'numeric_id' in transaction.input_data.train_df.columns
+        assert 'numeric_id' not in transaction.lmd['columns_to_ignore']
+
     def test_analyze_dataset_empty_column(self):
         n_points = 100
         input_dataframe = pd.DataFrame({
@@ -198,16 +231,18 @@ class TestPredictor:
 
         model_data = F.get_model_data('test_drop_duplicates')
 
-        # Ensure duplicate row was not used for training
+        # Ensure duplicate row was not used for training, or analysis
 
         assert model_data['data_preparation']['total_row_count'] == n_points
         assert model_data['data_preparation']['used_row_count'] <= n_points
-
 
         assert sum([model_data['data_preparation']['train_row_count'],
                    model_data['data_preparation']['validation_row_count'],
                    model_data['data_preparation']['test_row_count']]) == n_points
 
+        assert sum([mdb.transaction.input_data.train_df.shape[0],
+                    mdb.transaction.input_data.test_df.shape[0],
+                    mdb.transaction.input_data.validation_df.shape[0]]) == n_points
 
         # Disable deduplication and ensure the duplicate row is used
         mdb = Predictor(name='test_drop_duplicates')
@@ -223,7 +258,7 @@ class TestPredictor:
 
         model_data = F.get_model_data('test_drop_duplicates')
 
-        # Ensure duplicate row was not used for training
+        # Duplicate row was used for analysis and training
 
         assert model_data['data_preparation']['total_row_count'] == n_points+1
         assert model_data['data_preparation']['used_row_count'] <= n_points+1
@@ -231,6 +266,12 @@ class TestPredictor:
         assert sum([model_data['data_preparation']['train_row_count'],
                     model_data['data_preparation']['validation_row_count'],
                     model_data['data_preparation']['test_row_count']]) == n_points+1
+
+        assert sum([mdb.transaction.input_data.train_df.shape[0],
+                    mdb.transaction.input_data.test_df.shape[0],
+                    mdb.transaction.input_data.validation_df.shape[0]]) == n_points+1
+
+
 
     @pytest.mark.slow
     def test_explain_prediction(self):

--- a/tests/unit_tests/libs/controllers/test_predictor.py
+++ b/tests/unit_tests/libs/controllers/test_predictor.py
@@ -139,19 +139,21 @@ class TestPredictor:
 
     def test_ignore_columns(self):
         input_dataframe = pd.DataFrame({
-            'do_use': [1, 2, 3],
-            'ignore_this': [0, 1, 100]
+            'do_use': list(range(100)),
+            'y': list(range(100)),
+            'ignore_this': list(range(100, 0, -1))
         })
 
         predictor = Predictor(name='test')
-        transaction = predictor.learn(from_data=input_dataframe,
-                                      to_predict='do_use',
-                                      ignore_columns=['ignore_this']
+        predictor.learn(from_data=input_dataframe,
+                                      to_predict='y',
+                                      ignore_columns=['ignore_this'],
+                                      stop_training_in_x_seconds=1,
                                       )
+        transaction = predictor.transaction
 
-        assert 'do_use' in transaction.input_data.data_frame.columns
-        assert 'ignore_this' not in transaction.input_data.data_frame.columns
-
+        assert 'do_use' in transaction.input_data.train_df.columns
+        assert 'ignore_this' not in transaction.input_data.train_df.columns
 
     def test_analyze_dataset_empty_column(self):
         n_points = 100

--- a/tests/unit_tests/libs/controllers/test_predictor.py
+++ b/tests/unit_tests/libs/controllers/test_predictor.py
@@ -137,6 +137,22 @@ class TestPredictor:
             assert 'nr_warnings' in col_data
             assert not col_data['is_foreign_key']
 
+    def test_ignore_columns(self):
+        input_dataframe = pd.DataFrame({
+            'do_use': [1, 2, 3],
+            'ignore_this': [0, 1, 100]
+        })
+
+        predictor = Predictor(name='test')
+        transaction = predictor.learn(from_data=input_dataframe,
+                                      to_predict='do_use',
+                                      ignore_columns=['ignore_this']
+                                      )
+
+        assert 'do_use' in transaction.input_data.data_frame.columns
+        assert 'ignore_this' not in transaction.input_data.data_frame.columns
+
+
     def test_analyze_dataset_empty_column(self):
         n_points = 100
         input_dataframe = pd.DataFrame({

--- a/tests/unit_tests/libs/phases/data_cleaner/test_data_cleaner.py
+++ b/tests/unit_tests/libs/phases/data_cleaner/test_data_cleaner.py
@@ -1,0 +1,37 @@
+import pandas as pd
+import numpy as np
+import pytest
+
+from mindsdb_native.libs.data_types.transaction_data import TransactionData
+from mindsdb_native.libs.phases.data_cleaner.data_cleaner import DataCleaner
+
+
+class TestDataCleaner:
+    @pytest.fixture()
+    def lmd(self, transaction):
+        lmd = transaction.lmd
+        lmd['empty_columns'] = []
+        lmd['columns_to_ignore'] = []
+        lmd['predict_columns'] = []
+        return lmd
+
+    def test_ignore_columns(self, transaction, lmd):
+        data_cleaner = DataCleaner(session=transaction.session,
+                                   transaction=transaction)
+
+        input_dataframe = pd.DataFrame({
+            'do_use': [1, 2, 3],
+            'ignore_this': [0, 1, 100]
+        })
+
+        lmd['columns_to_ignore'].append('ignore_this')
+
+        input_data = TransactionData()
+        input_data.data_frame = input_dataframe
+
+        data_cleaner.transaction.input_data = input_data
+        data_cleaner.run()
+
+        assert 'do_use' in input_data.data_frame.columns
+        assert 'ignore_this' not in input_data.data_frame.columns
+


### PR DESCRIPTION
Tests for this hotfix: https://github.com/mindsdb/mindsdb_native/pull/74

As a bonus, added `--show-capture=no` default option to pytest. This hides log and stdout output.
If you need log output in tests, you can override it by passing `--show-capture=yes`:
https://docs.pytest.org/en/stable/logging.html