### PR TITLE
set ds 'table' param to None by default

### DIFF
--- a/mindsdb_native/libs/data_sources/maria_ds.py
+++ b/mindsdb_native/libs/data_sources/maria_ds.py
@@ -6,7 +6,7 @@ from mindsdb_native.libs.data_types.data_source import DataSource
 
 class MariaDS(DataSource):
 
-    def _setup(self, table, query=None, database='mysql', host='localhost',
+    def _setup(self, table=None, query=None, database='mysql', host='localhost',
                port=3306, user='root', password=''):
 
         self._database_name = database

--- a/mindsdb_native/libs/data_sources/ms_sql_ds.py
+++ b/mindsdb_native/libs/data_sources/ms_sql_ds.py
@@ -4,7 +4,7 @@ from mindsdb_native.libs.data_types.data_source import DataSource
 
 
 class MSSQLDS(DataSource):
-    def _setup(self, table, query=None, database='master', host='localhost',
+    def _setup(self, table=None, query=None, database='master', host='localhost',
                port=1433, user='sa', password=''):
 
         self._database_name = database

--- a/mindsdb_native/libs/data_sources/mysql_ds.py
+++ b/mindsdb_native/libs/data_sources/mysql_ds.py
@@ -6,7 +6,7 @@ from mindsdb_native.libs.data_types.data_source import DataSource
 
 class MySqlDS(DataSource):
 
-    def _setup(self, table, query=None, database='mysql', host='localhost',
+    def _setup(self, table=None, query=None, database='mysql', host='localhost',
                port=3306, user='root', password=''):
 
         self._database_name = database

--- a/mindsdb_native/libs/data_sources/postgres_ds.py
+++ b/mindsdb_native/libs/data_sources/postgres_ds.py
@@ -8,7 +8,7 @@ from mindsdb_native.libs.data_types.data_source import DataSource
 
 class PostgresDS(DataSource):
 
-    def _setup(self, table, query=None, database='postgres', host='localhost',
+    def _setup(self, table=None, query=None, database='postgres', host='localhost',
                port=5432, user='postgres', password=''):
 
         self._database_name = database


### PR DESCRIPTION
In mindsb 'table' arg not used when datasources creates, so it better to set it to None by default (except MongoDS, will think about it later)