### PR TITLE
change column importance formula

### DIFF
--- a/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
+++ b/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
@@ -51,7 +51,7 @@ class ModelAnalyzer(BaseModule):
         for col in ignorable_input_columns:
             accuracy_increase = (normal_accuracy - empty_input_accuracy[col])
             # normalize from 0 to 10
-            self.transaction.lmd['column_importances'][col] = 5 * (accuracy_increase + 1)
+            self.transaction.lmd['column_importances'][col] = 10 * max(0, accuracy_increase)
 
         # Run Probabilistic Validator
         overall_accuracy_arr = []

--- a/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
+++ b/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
@@ -49,9 +49,9 @@ class ModelAnalyzer(BaseModule):
         # Get some information about the importance of each column
         self.transaction.lmd['column_importances'] = {}
         for col in ignorable_input_columns:
-            column_importance = (1 - empty_input_accuracy[col]/normal_accuracy)
-            column_importance = np.ceil(10*column_importance)
-            self.transaction.lmd['column_importances'][col] = float(10 if column_importance > 10 else column_importance)
+            accuracy_increase = (normal_accuracy - empty_input_accuracy[col])
+            # normalize from 0 to 10
+            self.transaction.lmd['column_importances'][col] = 5 * (accuracy_increase + 1)
 
         # Run Probabilistic Validator
         overall_accuracy_arr = []


### PR DESCRIPTION
resolves https://github.com/mindsdb/mindsdb_native/issues/36

**column importance**
equal to 0.5 means removing the column doesn't affect the accuracy
below 0.5 means removing the column increases the accuracy
above 0.5 means removing the column decreases the accuracy

previously the formula was:
`column_importance = (1 - empty_input_accuracy[col] / normal_accuracy)`
examples of values that will result in negative column importance:
```
empty_input_accuracy[col] = 1.0
normal_accuracy = 0.9

column_importance = (1 - empty_input_accuracy[col] / normal_accuracy) = (1 - 1.111) = -0.111
```



