### PR TITLE
 allow failing for categorical and numerical output

### DIFF
--- a/mindsdb_native/libs/controllers/predictor.py
+++ b/mindsdb_native/libs/controllers/predictor.py
@@ -231,6 +231,7 @@ class Predictor:
                 deduplicate_data = advanced_args.get('deduplicate_data', True),
                 null_values = advanced_args.get('null_values', {}),
                 data_split_indexes = advanced_args.get('data_split_indexes', None),
+                force_predict = advanced_args.get('force_predict', False),
 
                 breakpoint=self.breakpoint
             )

--- a/mindsdb_native/libs/phases/data_analyzer/data_analyzer.py
+++ b/mindsdb_native/libs/phases/data_analyzer/data_analyzer.py
@@ -298,11 +298,13 @@ class DataAnalyzer(BaseModule):
                         outliers = lof_outliers(data_subtype, col_data)
                         stats_v2[col_name]['outliers'] = {
                             'outlier_values': outliers,
-                            'outlier_buckets': compute_outlier_buckets(outlier_values=outliers,
-                                                                    hist_x=histogram['x'],
-                                                                    hist_y=histogram['y'],
-                                                                    percentage_buckets=percentage_buckets,
-                                                                    col_stats=stats_v2[col_name]),
+                            'outlier_buckets': compute_outlier_buckets(
+                                outlier_values=outliers,
+                                hist_x=histogram['x'],
+                                hist_y=histogram['y'],
+                                percentage_buckets=percentage_buckets,
+                                col_stats=stats_v2[col_name]
+                            ),
                             'description': """Potential outliers can be thought as the "extremes", i.e., data points that are far from the center of mass (mean/median/interquartile range) of the data."""
                         }
 

--- a/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
+++ b/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
@@ -48,7 +48,7 @@ class ModelAnalyzer(BaseModule):
                 pass
 
             if fails:
-                if self.transaction.lmd['force_predict']:
+                if not self.transaction.lmd['force_predict']:
                     def predict_wrapper(*args, **kwargs):
                         raise Exception('Failed to train model')
                     self.session.predict = predict_wrapper

--- a/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
+++ b/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
@@ -37,11 +37,18 @@ class ModelAnalyzer(BaseModule):
             preds = normal_predictions[col]
 
             fails = False
-
-            if self.transaction.lmd['stats_v2'][col]['typing']['data_type'] == DATA_TYPES.CATEGORICAL:
-                if accuracy_score(reals, preds) < self.transaction.lmd['stats_v2'][col]['guess_probability']:
-                    fails = True
-            elif self.transaction.lmd['stats_v2'][col]['typing']['data_type'] == DATA_TYPES.NUMERIC:
+            
+            data_type = self.transaction.lmd['stats_v2'][col]['typing']['data_type']
+            data_subtype = self.transaction.lmd['stats_v2'][col]['typing']['data_subtype']
+            
+            if data_type == DATA_TYPES.CATEGORICAL:
+                if data_subtype == DATA_SUBTYPES.TAGS:
+                    # need to implement stats_v2[col]['guess_probability'] for tags
+                    pass
+                else:
+                    if accuracy_score(reals, preds) < self.transaction.lmd['stats_v2'][col]['guess_probability']:
+                        fails = True
+            elif data_type == DATA_TYPES.NUMERIC:
                 if r2_score(reals, preds) < 0:
                     fails = True
             else:

--- a/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
+++ b/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
@@ -4,6 +4,7 @@ from mindsdb_native.libs.phases.base_module import BaseModule
 from mindsdb_native.libs.helpers.general_helpers import evaluate_accuracy
 from mindsdb_native.libs.helpers.probabilistic_validator import ProbabilisticValidator
 from mindsdb_native.libs.data_types.mindsdb_logger import log
+from skleran.metrics import accuracy_score, r2_score
 
 import pandas as pd
 import numpy as np
@@ -31,7 +32,6 @@ class ModelAnalyzer(BaseModule):
                                             output_columns,
                                             backend=self.transaction.model_backend)
         
-        exit('bye')
         for col in output_columns:
             reals = self.transaction.input_data.validation_df[col]
             preds = normal_predictions[col]
@@ -39,13 +39,13 @@ class ModelAnalyzer(BaseModule):
             fails = False
 
             if self.transaction.lmd['stats_v2'][col]['data_type'] == DATA_TYPES.CATEGORICAL:
-                from skleran.metrics import accuracy_score
                 if accuracy_score(reals, preds) < self.transaction.lmd['stats_v2'][col]['guess_probability']:
                     fails = True
             elif self.transaction.lmd['stats_v2'][col]['data_type'] == DATA_TYPES.NUMERIC:
-                from sklearn.metrics import r2_score
                 if r2_score(reals, preds) < 0:
                     fails = True
+            else:
+                pass
                 
             if fails:
                 if self.transaction.lmd['force_predict']:

--- a/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
+++ b/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
@@ -3,6 +3,7 @@ from mindsdb_native.libs.constants.mindsdb import *
 from mindsdb_native.libs.phases.base_module import BaseModule
 from mindsdb_native.libs.helpers.general_helpers import evaluate_accuracy
 from mindsdb_native.libs.helpers.probabilistic_validator import ProbabilisticValidator
+from mindsdb_native.libs.data_types.mindsdb_logger import log
 
 import pandas as pd
 import numpy as np
@@ -29,6 +30,27 @@ class ModelAnalyzer(BaseModule):
                                             self.transaction.lmd['stats_v2'],
                                             output_columns,
                                             backend=self.transaction.model_backend)
+        
+        exit('bye')
+        for col in output_columns:
+            reals = self.transaction.input_data.validation_df[col]
+            preds = normal_predictions[col]
+
+            fails = False
+
+            if self.transaction.lmd['stats_v2'][col]['data_type'] == DATA_TYPES.CATEGORICAL:
+                from skleran.metrics import accuracy_score
+                if accuracy_score(reals, preds) < self.transaction.lmd['stats_v2'][col]['guess_probability']:
+                    fails = True
+            elif self.transaction.lmd['stats_v2'][col]['data_type'] == DATA_TYPES.NUMERIC:
+                from sklearn.metrics import r2_score
+                if r2_score(reals, preds) < 0:
+                    fails = True
+                
+            if fails:
+                if self.transaction.lmd['force_predict']:
+                    self.session.predict = lambda *args, **kwargs: raise Exception('Failed to train model')
+                log.error('Failed to train model')
 
         empty_input_predictions = {}
         empty_input_accuracy = {}

--- a/tests/unit_tests/libs/controllers/test_predictor.py
+++ b/tests/unit_tests/libs/controllers/test_predictor.py
@@ -293,7 +293,8 @@ class TestPredictor:
             from_data=input_dataframe,
             to_predict='numeric_y',
             stop_training_in_x_seconds=1,
-            use_gpu=False
+            use_gpu=False,
+            advanced_args={'force_predict': True}
         )
 
         result = mdb.predict(when_data={"numeric_x": 10, 'categorical_x': 1})
@@ -497,10 +498,13 @@ class TestPredictor:
                         headers=feature_headers)
 
         mdb = Predictor(name='test_multilabel_prediction')
-        mdb.learn(from_data=train_file_name,
-                  to_predict=label_headers,
-                  stop_training_in_x_seconds=1,
-                  use_gpu=False)
+        mdb.learn(
+            from_data=train_file_name,
+            to_predict=label_headers,
+            stop_training_in_x_seconds=1,
+            use_gpu=False,
+            advanced_args={'force_predict': True}
+        )
 
         results = mdb.predict(when_data=test_file_name)
         models = F.get_models()


### PR DESCRIPTION
https://github.com/mindsdb/mindsdb_native/issues/106
- Model training can fail (which means an error will be logged and you will get an exception on attempt to call `predict()` on the `Predictor` instance) for numerical and categorical data types for now.
- Added `force_predict` boolean flag (`False` by default) to `advanced_args` which will allow to call `predict()` on the `Predictor` instance if model training failed.