### PR TITLE
stats for tags

### DIFF
--- a/mindsdb_native/libs/controllers/predictor.py
+++ b/mindsdb_native/libs/controllers/predictor.py
@@ -231,6 +231,7 @@ class Predictor:
                 deduplicate_data = advanced_args.get('deduplicate_data', True),
                 null_values = advanced_args.get('null_values', {}),
                 data_split_indexes = advanced_args.get('data_split_indexes', None),
+                tags_delimiter = advanced_args.get('tags_delimiter', ','),
 
                 breakpoint=self.breakpoint
             )

--- a/mindsdb_native/libs/phases/data_analyzer/data_analyzer.py
+++ b/mindsdb_native/libs/phases/data_analyzer/data_analyzer.py
@@ -327,15 +327,10 @@ class DataAnalyzer(BaseModule):
                     delimiter = self.transaction.lmd.get('tags_delimiter', ',')
                     data = [x.strip() for x in (item.split(delimiter) for item in col_data)]
 
-                    tag_set = set()
+                    stats_v2[col_name]['tag_hist'] = Counter()
                     for arr in data:
-                        tag_set.update(arr)
-                    stats_v2[col_name]['tag_set'] = tag_set
-
-                    tag_counter = Counter()
-                    for arr in data:
-                        tag_counter.update(arr)
-                    stats_v2[col_name]['guess_probability'] = sum((v / len(data))**2 for v in tag_counter.values())
+                        stats_v2[col_name]['tag_hist'].update(arr)
+                    stats_v2[col_name]['guess_probability'] = sum((v / len(data))**2 for v in stats_v2[col_name]['tag_hist'].values())
                 else:
                     total = sum(histogram['y'])
                     stats_v2[col_name]['guess_probability'] = sum((v / total)**2 for v in histogram['y'])

--- a/mindsdb_native/libs/phases/data_analyzer/data_analyzer.py
+++ b/mindsdb_native/libs/phases/data_analyzer/data_analyzer.py
@@ -323,9 +323,12 @@ class DataAnalyzer(BaseModule):
             self.log.info(f'Finished analyzing column: {col_name} !\n')
 
             if data_type == DATA_TYPES.CATEGORICAL:
-                total = sum(histogram['y'])
-                stats_v2[col_name]['guess_probability'] = sum((v / total)**2 for v in histogram['y'])
-        
+                if data_subtype == DATA_SUBTYPES.TAGS:
+                    print(stats_v2)
+                else:
+                    total = sum(histogram['y'])
+                    stats_v2[col_name]['guess_probability'] = sum((v / total)**2 for v in histogram['y'])
+        exit('bye')d
         self.transaction.lmd['data_preparation']['accepted_margin_of_error'] = self.transaction.lmd['sample_settings']['sample_margin_of_error']
 
         self.transaction.lmd['data_preparation']['total_row_count'] = len(input_data.data_frame)

--- a/mindsdb_native/libs/phases/data_analyzer/data_analyzer.py
+++ b/mindsdb_native/libs/phases/data_analyzer/data_analyzer.py
@@ -324,11 +324,22 @@ class DataAnalyzer(BaseModule):
 
             if data_type == DATA_TYPES.CATEGORICAL:
                 if data_subtype == DATA_SUBTYPES.TAGS:
-                    print(stats_v2)
+                    delimiter = self.transaction.lmd.get('tags_delimiter', ',')
+                    data = [x.strip() for x in item.split(delimiter) for item in col_data]
+
+                    tag_set = set()
+                    for arr in data:
+                        tag_set.update(arr)
+                    stats_v2[col_name]['tag_set'] = tag_set
+
+                    tag_counter = Counter()
+                    for arr in data:
+                        tag_counter.update(arr)
+                    stats_v2[col_name]['guess_probability'] = sum((v / len(data))**2 for v in tag_counter.values())
                 else:
                     total = sum(histogram['y'])
                     stats_v2[col_name]['guess_probability'] = sum((v / total)**2 for v in histogram['y'])
-        exit('bye')d
+
         self.transaction.lmd['data_preparation']['accepted_margin_of_error'] = self.transaction.lmd['sample_settings']['sample_margin_of_error']
 
         self.transaction.lmd['data_preparation']['total_row_count'] = len(input_data.data_frame)

--- a/mindsdb_native/libs/phases/data_analyzer/data_analyzer.py
+++ b/mindsdb_native/libs/phases/data_analyzer/data_analyzer.py
@@ -325,8 +325,7 @@ class DataAnalyzer(BaseModule):
             if data_type == DATA_TYPES.CATEGORICAL:
                 if data_subtype == DATA_SUBTYPES.TAGS:
                     delimiter = self.transaction.lmd.get('tags_delimiter', ',')
-                    data = [x.strip() for x in (item.split(delimiter) for item in col_data)]
-
+                    data = [[x.strip() for x in item.split(delimiter)] for item in col_data]
                     stats_v2[col_name]['tag_hist'] = Counter()
                     for arr in data:
                         stats_v2[col_name]['tag_hist'].update(arr)

--- a/mindsdb_native/libs/phases/data_analyzer/data_analyzer.py
+++ b/mindsdb_native/libs/phases/data_analyzer/data_analyzer.py
@@ -325,7 +325,7 @@ class DataAnalyzer(BaseModule):
             if data_type == DATA_TYPES.CATEGORICAL:
                 if data_subtype == DATA_SUBTYPES.TAGS:
                     delimiter = self.transaction.lmd.get('tags_delimiter', ',')
-                    data = [x.strip() for x in item.split(delimiter) for item in col_data]
+                    data = [x.strip() for x in (item.split(delimiter) for item in col_data)]
 
                     tag_set = set()
                     for arr in data:

--- a/mindsdb_native/libs/phases/type_deductor/type_deductor.py
+++ b/mindsdb_native/libs/phases/type_deductor/type_deductor.py
@@ -208,10 +208,11 @@ class TypeDeductor(BaseModule):
             unique_tokens = set()
 
             can_be_tags = False
-            if len(data) == len([x for x in data if isinstance(x,str)]):
+            if all(isinstance(x, str) for x in data):
                 can_be_tags = True
+                delimiter = self.transaction.lmd.get('tags_delimiter', ',')
                 for item in data:
-                    item_tags = [t.strip() for t in item.split(',')]
+                    item_tags = [t.strip() for t in item.split(delimiter)]
                     lengths.append(len(item_tags))
                     unique_tokens = unique_tokens.union(set(item_tags))
 


### PR DESCRIPTION
- add support for `tags_delimiter` advanced arg (`','` by default)
- add `'tag_set'` to `stats_v2` which is the set of all tags
- add `'guess_probability'` to `stats_v2` for tags