### PR TITLE
Allow fail for tags

### DIFF
--- a/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
+++ b/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
@@ -1,7 +1,10 @@
 from mindsdb_native.libs.helpers.general_helpers import pickle_obj, disable_console_output
 from mindsdb_native.libs.constants.mindsdb import *
 from mindsdb_native.libs.phases.base_module import BaseModule
-from mindsdb_native.libs.helpers.general_helpers import evaluate_accuracy
+from mindsdb_native.libs.helpers.general_helpers import (
+    evaluate_accuracy,
+    evaluate_multilabel_accuracy
+)
 from mindsdb_native.libs.helpers.probabilistic_validator import ProbabilisticValidator
 from mindsdb_native.libs.data_types.mindsdb_logger import log
 from sklearn.metrics import accuracy_score, r2_score
@@ -43,8 +46,9 @@ class ModelAnalyzer(BaseModule):
             
             if data_type == DATA_TYPES.CATEGORICAL:
                 if data_subtype == DATA_SUBTYPES.TAGS:
-                    # need to implement stats_v2[col]['guess_probability'] for tags
-                    pass
+                    encoder = backend.predictor._mixer.encoders[column]
+                    if accuracy_score(encoder.encode(reals), encoder.encode(preds)) < self.transaction.lmd['stats_v2'][col]['guess_probability']:
+                        fails = True
                 else:
                     if accuracy_score(reals, preds) < self.transaction.lmd['stats_v2'][col]['guess_probability']:
                         fails = True

--- a/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
+++ b/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
@@ -46,7 +46,7 @@ class ModelAnalyzer(BaseModule):
             
             if data_type == DATA_TYPES.CATEGORICAL:
                 if data_subtype == DATA_SUBTYPES.TAGS:
-                    encoder = backend.predictor._mixer.encoders[column]
+                    encoder = self.transaction.model_backend.predictor._mixer.encoders[column]
                     if accuracy_score(encoder.encode(reals), encoder.encode(preds)) < self.transaction.lmd['stats_v2'][col]['guess_probability']:
                         fails = True
                 else:

--- a/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
+++ b/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
@@ -47,10 +47,10 @@ class ModelAnalyzer(BaseModule):
             if data_type == DATA_TYPES.CATEGORICAL:
                 if data_subtype == DATA_SUBTYPES.TAGS:
                     encoder = self.transaction.model_backend.predictor._mixer.encoders[col]
-                    if accuracy_score(encoder.encode(reals), encoder.encode(preds)) < self.transaction.lmd['stats_v2'][col]['guess_probability']:
+                    if accuracy_score(encoder.encode(reals), encoder.encode(preds)) <= self.transaction.lmd['stats_v2'][col]['guess_probability']:
                         fails = True
                 else:
-                    if accuracy_score(reals, preds) < self.transaction.lmd['stats_v2'][col]['guess_probability']:
+                    if accuracy_score(reals, preds) <= self.transaction.lmd['stats_v2'][col]['guess_probability']:
                         fails = True
             elif data_type == DATA_TYPES.NUMERIC:
                 if r2_score(reals, preds) < 0:

--- a/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
+++ b/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
@@ -46,7 +46,7 @@ class ModelAnalyzer(BaseModule):
             
             if data_type == DATA_TYPES.CATEGORICAL:
                 if data_subtype == DATA_SUBTYPES.TAGS:
-                    encoder = self.transaction.model_backend.predictor._mixer.encoders[column]
+                    encoder = self.transaction.model_backend.predictor._mixer.encoders[col]
                     if accuracy_score(encoder.encode(reals), encoder.encode(preds)) < self.transaction.lmd['stats_v2'][col]['guess_probability']:
                         fails = True
                 else:

--- a/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
+++ b/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
@@ -1,10 +1,7 @@
 from mindsdb_native.libs.helpers.general_helpers import pickle_obj, disable_console_output
 from mindsdb_native.libs.constants.mindsdb import *
 from mindsdb_native.libs.phases.base_module import BaseModule
-from mindsdb_native.libs.helpers.general_helpers import (
-    evaluate_accuracy,
-    evaluate_multilabel_accuracy
-)
+from mindsdb_native.libs.helpers.general_helpers import evaluate_accuracy
 from mindsdb_native.libs.helpers.probabilistic_validator import ProbabilisticValidator
 from mindsdb_native.libs.data_types.mindsdb_logger import log
 from sklearn.metrics import accuracy_score, r2_score


### PR DESCRIPTION
- training a predictor can fail for `TAGS` data type