### PR TITLE
Restore TimeSeries test, fix get_model_data()

### DIFF
--- a/mindsdb_native/libs/controllers/functional.py
+++ b/mindsdb_native/libs/controllers/functional.py
@@ -474,7 +474,8 @@ def get_model_data(model_name=None, lmd=None):
             amd['model_analysis'].append(mao)
         else:
             if 'column_importances' in lmd and lmd['column_importances'] is not None:
-                icm['importance_score'] = lmd['column_importances'][col]
+                if col not in [x[0] for x in lmd['model_order_by']]:
+                    icm['importance_score'] = lmd['column_importances'][col]
             amd['data_analysis']['input_columns_metadata'].append(icm)
 
     return amd

--- a/mindsdb_native/libs/helpers/general_helpers.py
+++ b/mindsdb_native/libs/helpers/general_helpers.py
@@ -10,6 +10,7 @@ from sklearn.metrics import balanced_accuracy_score, accuracy_score, f1_score
 import os
 import sys
 
+
 from mindsdb_native.__about__ import __version__
 from mindsdb_native.config import CONFIG
 from mindsdb_native.libs.data_types.mindsdb_logger import log

--- a/mindsdb_native/libs/helpers/general_helpers.py
+++ b/mindsdb_native/libs/helpers/general_helpers.py
@@ -10,7 +10,6 @@ from sklearn.metrics import balanced_accuracy_score, accuracy_score, f1_score
 import os
 import sys
 
-
 from mindsdb_native.__about__ import __version__
 from mindsdb_native.config import CONFIG
 from mindsdb_native.libs.data_types.mindsdb_logger import log

--- a/tests/unit_tests/libs/controllers/test_predictor.py
+++ b/tests/unit_tests/libs/controllers/test_predictor.py
@@ -457,7 +457,7 @@ class TestPredictor:
             order_by=feature_headers[0],
             # ,window_size_seconds=ts_hours* 3600 * 1.5
             window_size=3,
-            stop_training_in_x_seconds=1,
+            stop_training_in_x_seconds=10,
             use_gpu=False
         )
 

--- a/tests/unit_tests/libs/controllers/test_predictor.py
+++ b/tests/unit_tests/libs/controllers/test_predictor.py
@@ -424,7 +424,6 @@ class TestPredictor:
         assert (a2['existing_credits']['typing'][
                     'data_subtype'] == DATA_SUBTYPES.SINGLE)
 
-    @pytest.mark.skip(reason='Test gets stuck during learn call, need investigation')
     @pytest.mark.slow
     def test_timeseries(self, tmp_path):
         ts_hours = 12


### PR DESCRIPTION
The time series test was being skipped because of the issue solved [here](https://github.com/mindsdb/lightwood/pull/247). 

Once reinstated, however, it was failing with a `KeyError` because of the `order_by` column not being analyzed in the `column_importance` process (thus, not included in the `lmd['column_importances']` dictionary). 

This PR reactivates the test, and adds a quick fix so that it passes.