### PR TITLE
Send number of predictions

### DIFF
--- a/mindsdb_native/libs/backends/lightwood.py
+++ b/mindsdb_native/libs/backends/lightwood.py
@@ -184,7 +184,7 @@ class LightwoodBackend():
                 if self.transaction.lmd['tss']['is_timeseries']:
                     col_config['additional_info'] = {
                         'nr_predictions': self.transaction.lmd['tss']['nr_predictions']
-                    }``
+                    }
                 config['output_features'].append(col_config)
             else:
                 config['input_features'].append(col_config)

--- a/mindsdb_native/libs/backends/lightwood.py
+++ b/mindsdb_native/libs/backends/lightwood.py
@@ -181,6 +181,10 @@ class LightwoodBackend():
             col_config.update(other_keys)
 
             if col_name in self.transaction.lmd['predict_columns']:
+                if self.transaction.lmd['tss']['is_timeseries']:
+                    col_config['additional_info'] = {
+                        'nr_predictions': self.transaction.lmd['tss']['nr_predictions']
+                    }``
                 config['output_features'].append(col_config)
             else:
                 config['input_features'].append(col_config)
@@ -269,7 +273,7 @@ class LightwoodBackend():
                 lightwood_config['mixer']['kwargs']['stop_training_after_seconds'] = self.transaction.lmd['stop_training_in_x_seconds']
 
         logging.getLogger().setLevel(logging.DEBUG)
-       
+
         self.predictor.learn(from_data=train_df, test_data=test_df)
 
         self.transaction.log.info('Training accuracy of: {}'.format(self.predictor.train_accuracy))


### PR DESCRIPTION
Send the number of predictions to be made for target in timeseries datasets to lightwood (In the column config under: `additional_info->nr_predictions`)