### PR TITLE
Improve history query generation

### DIFF
--- a/mindsdb_native/libs/helpers/query_composer.py
+++ b/mindsdb_native/libs/helpers/query_composer.py
@@ -8,17 +8,24 @@ i_li = re.compile(re.escape(' limit '), re.IGNORECASE)
 
 def create_history_query(query, tss, stats, row):
     group_by_filter = []
-    group_by_arr = tss['group_by'] if tss['group_by'] is not None else []
-    for group_column in group_by_arr:
-        if stats[group_column]['typing']['data_type'] in [DATA_TYPES.TEXT,DATA_TYPES.CATEGORICAL]:
+    for group_column in tss['group_by'] if tss['group_by'] is not None else []:
+        if stats[group_column]['typing']['data_type'] in [DATA_TYPES.TEXT,DATA_TYPES.CATEGORICAL,DATA_TYPES.DATE]:
             group_by_filter.append(f'{group_column}=' + "'" + str(row[group_column]) + "'")
         else:
             group_by_filter.append(f'{group_column}=' + str(row[group_column]))
 
-    group_by_filter = ' AND '.join(group_by_filter)
+    order_by_filter = []
+    for order_column in tss['order_by']:
+        if stats[order_column]['typing']['data_type'] in [DATA_TYPES.DATE]:
+            order_by_filter.append(f'{order_column}<' + "'" + str(row[order_column]) + "'")
+        else:
+            order_by_filter.append(f'{order_column}<' + str(row[order_column]))
+
+    merged_filter = ' AND '.join([*order_by_filter,*group_by_filter])
+
 
     order_by_list = []
-    for order_column in tss.get('order_by'):
+    for order_column in tss['order_by']:
         order_by_list.append(order_column)
     order_by_list = ', '.join(order_by_list)
 
@@ -38,21 +45,21 @@ def create_history_query(query, tss, stats, row):
                 query = ' limit '.join(split_query[:-1])
 
     # append filter
-    if len(group_by_filter) > 0:
+    if len(merged_filter) > 0:
         if ' where ' in query:
             split_query = query.split(' where ')
-            query = split_query[0] + f' WHERE {group_by_filter} AND ' + split_query[1]
+            query = split_query[0] + f' WHERE {merged_filter} AND ' + split_query[1]
         elif ' group by ' in query:
             split_query = query.split(' group by ')
-            query = split_query[0] + f' WHERE {group_by_filter} ' + split_query[1]
+            query = split_query[0] + f' WHERE {merged_filter} ' + split_query[1]
         elif ' having ' in query:
             split_query = query.split(' having ')
-            query = split_query[0] + f' WHERE {group_by_filter} ' + split_query[1]
+            query = split_query[0] + f' WHERE {merged_filter} ' + split_query[1]
         elif ' order by ' in query:
             split_query = query.split(' order by ')
-            query = split_query[0] + f' WHERE {group_by_filter} ' + split_query[1]
+            query = split_query[0] + f' WHERE {merged_filter} ' + split_query[1]
         else:
-            query += f' WHERE {group_by_filter}'
+            query += f' WHERE {merged_filter}'
 
     # append order
     if ' order by ' in query:

--- a/mindsdb_native/libs/helpers/query_composer.py
+++ b/mindsdb_native/libs/helpers/query_composer.py
@@ -18,7 +18,7 @@ def create_history_query(query, tss, stats, row):
     for order_column in tss['order_by']:
         if stats[order_column]['typing']['data_type'] in [DATA_TYPES.DATE]:
             order_by_filter.append(f'{order_column}<' + "'" + str(row[order_column]) + "'")
-        else:
+        elif stats[order_column]['typing']['data_type'] in [DATA_TYPES.NUMERIC]:
             order_by_filter.append(f'{order_column}<' + str(row[order_column]))
 
     merged_filter = ' AND '.join([*order_by_filter,*group_by_filter])

--- a/tests/unit_tests/libs/helpers/test_query_composer.py
+++ b/tests/unit_tests/libs/helpers/test_query_composer.py
@@ -43,4 +43,4 @@ def test_query_composer():
     tss['group_by'] = ['C']
     tss['order_by'] = ['A','B']
     new_query = create_history_query('select * from table where z=55 group by W order by N limit 500;', tss, stats, {'A': 100, 'B': 500, 'C': 'value of C'})
-    assert new_query.lower() == 'select * from table where C=\'value of C\' AND z=55 group by W order by A, B DESC limit 6'.lower()
+    assert new_query.lower() == 'select * from table where B<500 AND C=\'value of C\' AND z=55 group by W order by A, B DESC limit 6'.lower()


### PR DESCRIPTION
When generating the historical query to timeseries, we'll only going to select rows where the order by columns are smaller than the value of the order by columns in the current row.