### PR TITLE
Allow predicting with timesteps

### DIFF
--- a/mindsdb_native/libs/backends/lightwood.py
+++ b/mindsdb_native/libs/backends/lightwood.py
@@ -356,7 +356,7 @@ class LightwoodBackend():
             validation_predictions = self.predict('validate')
             validation_accuracy = evaluate_accuracy(
                 validation_predictions,
-                self.transaction.input_data.validation_df,
+                self.transaction.input_data.clean_validation_df,
                 self.transaction.lmd['stats_v2'],
                 self.transaction.lmd['predict_columns'],
                 backend=self
@@ -427,7 +427,7 @@ class LightwoodBackend():
         for k in predictions:
             if '_timestep_' in k:
                 continue
-            
+
             formated_predictions[k] = predictions[k]['predictions']
 
             if self.nr_predictions > 1:

--- a/mindsdb_native/libs/backends/lightwood.py
+++ b/mindsdb_native/libs/backends/lightwood.py
@@ -441,24 +441,28 @@ class LightwoodBackend():
                     for i in range(len(formated_predictions[k])):
                         formated_predictions[k][i].append(predictions[f'{k}_timestep_{timestep_index}']['predictions'][i])
 
-            model_confidence = []
+            model_confidence_dict = {}
             for confidence_name in ['selfaware_confidences','loss_confidences', 'quantile_confidences']:
-
                 if confidence_name in predictions[k]:
+                    if k not in model_confidence_dict:
+                        model_confidence_dict[k] = []
 
                     for i in range(len(predictions[k][confidence_name])):
-                        if len(model_confidence) <= i:
-                            model_confidence.append([])
+                        if len(model_confidence_dict[k]) <= i:
+                            model_confidence_dict[k].append([])
                         conf = predictions[k][confidence_name][i]
                         # @TODO We should make sure lightwood never returns confidences above or bellow 0 and 1
                         if conf < 0:
                             conf = 0
                         if conf > 1:
                             conf = 1
-                        model_confidence[i].append(conf)
+                        model_confidence_dict[k][i].append(conf)
 
-            # @TODO: This is weird
-            formated_predictions[f'{k}_model_confidence'] = [np.mean(x) for x in model_confidence]
+            for k in model_confidence_dict:
+                model_confidence_dict[k] = [np.mean(x) for x in model_confidence_dict[k]]
+
+            for k in model_confidence_dict:
+                formated_predictions[f'{k}_model_confidence'] = model_confidence_dict[k]
 
             if 'confidence_range' in predictions[k]:
                 formated_predictions[f'{k}_confidence_range'] = predictions[k]['confidence_range']

--- a/mindsdb_native/libs/backends/lightwood.py
+++ b/mindsdb_native/libs/backends/lightwood.py
@@ -354,9 +354,14 @@ class LightwoodBackend():
             ))
 
             validation_predictions = self.predict('validate')
+
+            validation_df = self.transaction.input_data.validation_df
+            if self.transaction.lmd['tss']['is_timeseries']:
+                validation_df = self.transaction.input_data.validation_df[self.transaction.input_data.validation_df['make_predictions'] == True]
+
             validation_accuracy = evaluate_accuracy(
                 validation_predictions,
-                self.transaction.input_data.clean_validation_df,
+                validation_df,
                 self.transaction.lmd['stats_v2'],
                 self.transaction.lmd['predict_columns'],
                 backend=self

--- a/mindsdb_native/libs/backends/lightwood.py
+++ b/mindsdb_native/libs/backends/lightwood.py
@@ -115,7 +115,7 @@ class LightwoodBackend():
                         previous_target_values_arr.append(arr)
 
                     ts_groups[k][f'previous_{target_column}'] = previous_target_values_arr
-                    for timestep_index in range(1,self.nr_predictions):
+                    for timestep_index in range(1, self.nr_predictions):
                         next_target_value_arr = list(ts_groups[k][target_column])
                         for del_index in range(0,timestep_index):
                             del next_target_value_arr[del_index]
@@ -218,6 +218,8 @@ class LightwoodBackend():
                     config['input_features'].append(p_col_config)
 
                 if self.nr_predictions > 1:
+                    self.transaction.lmd['stats_v2'][col_name]['typing']['data_subtype'] = DATA_SUBTYPES.ARRAY
+                    self.transaction.lmd['stats_v2'][col_name]['typing']['data_type'] = DATA_TYPES.SEQUENTIAL
                     for timestep_index in range(1,self.nr_predictions):
                         additional_target_config = copy.deepcopy(col_config)
                         additional_target_config['name'] = f'{col_name}_timestep_{timestep_index}'
@@ -423,6 +425,9 @@ class LightwoodBackend():
         formated_predictions = {}
 
         for k in predictions:
+            if '_timestep_' in k:
+                continue
+            
             formated_predictions[k] = predictions[k]['predictions']
 
             if self.nr_predictions > 1:

--- a/mindsdb_native/libs/controllers/transaction.py
+++ b/mindsdb_native/libs/controllers/transaction.py
@@ -273,7 +273,7 @@ class PredictTransaction(Transaction):
             self._call_phase_module(module_name='DataSplitter')
 
         # @TODO Maybe move to a separate "PredictionAnalysis" phase ?
-        if self.lmd['run_confidence_variation_analysis']:
+        if self.lmd['run_confidence_variation_analysis'] and not self.lmd['tss']['is_timeseries']:
             nulled_out_data = []
             nulled_out_columns = []
             for column in self.input_data.columns:
@@ -287,7 +287,7 @@ class PredictTransaction(Transaction):
 
         for mode in ['predict', 'analyze_confidence']:
             if mode == 'analyze_confidence':
-                if not self.lmd['run_confidence_variation_analysis']:
+                if not self.lmd['run_confidence_variation_analysis'] or self.lmd['tss']['is_timeseries']:
                     continue
                 else:
                     self.input_data.data_frame = nulled_out_data

--- a/mindsdb_native/libs/controllers/transaction.py
+++ b/mindsdb_native/libs/controllers/transaction.py
@@ -377,7 +377,7 @@ class PredictTransaction(Transaction):
             else:
                 nulled_out_predictions = PredictTransactionOutputData(transaction=self, data=output_data)
 
-        if self.lmd['run_confidence_variation_analysis']:
+        if self.lmd['run_confidence_variation_analysis'] and not self.lmd['tss']['is_timeseries']:
             input_confidence = {}
             extra_insights = {}
 

--- a/mindsdb_native/libs/data_types/transaction_data.py
+++ b/mindsdb_native/libs/data_types/transaction_data.py
@@ -6,6 +6,7 @@ class TransactionData:
         self.train_df = None
         self.test_df = None
         self.validation_df = None
+        self.clean_validation_df = None
         self.historical_train_df = None
         self.historical_test_df = None
         self.columns = []

--- a/mindsdb_native/libs/helpers/general_helpers.py
+++ b/mindsdb_native/libs/helpers/general_helpers.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import uuid
 from contextlib import contextmanager
 
-from sklearn.metrics import balanced_accuracy_score, accuracy_score, f1_score
+from sklearn.metrics import balanced_accuracy_score, accuracy_score, f1_score, r2_score
 import os
 import sys
 
@@ -164,14 +164,14 @@ def evaluate_generic_accuracy(column, predictions, true_values, backend):
 
 def evaluate_array_accuracy(column, predictions, true_values, backend):
     accuracy = 0
+    true_values = list(true_values)
     for i in range(len(predictions[column])):
         if isinstance(true_values[i],list):
-            accuracy += f1_score(predictions[column][i],true_values[i])
+            accuracy += r2_score(predictions[column][i],true_values[i])
         else:
             # For the T+1 usecase
-            print([x[0] for x in predictions[column]], ' ||| ', list(true_values), ' ||| ', len(list(true_values)), len(predictions[column]), len(([x[0] for x in predictions[column]])))
-            accuracy = f1_score([x[0] for x in predictions[column]], true_values)
-            break
+            accuracy = r2_score([x[0] for x in predictions[column]], true_values)
+            return accuracy
 
     accuracy = accuracy/len(predictions[column])
     return accuracy
@@ -182,7 +182,6 @@ def evaluate_accuracy(predictions, data_frame, col_stats, output_columns, backen
     for column in output_columns:
         col_type = col_stats[column]['typing']['data_type']
         col_subtype = col_stats[column]['typing']['data_subtype']
-        print(col_type, col_subtype, column)
         if col_type == DATA_TYPES.NUMERIC:
             evaluator = evaluate_regression_accuracy
         elif col_type == DATA_TYPES.CATEGORICAL:

--- a/mindsdb_native/libs/helpers/general_helpers.py
+++ b/mindsdb_native/libs/helpers/general_helpers.py
@@ -162,12 +162,27 @@ def evaluate_generic_accuracy(column, predictions, true_values, backend):
     pred_values = predictions[column]
     return accuracy_score(true_values, pred_values)
 
+def evaluate_array_accuracy(column, predictions, true_values, backend):
+    accuracy = 0
+    for i in range(len(predictions[column])):
+        if isinstance(true_values[i],list):
+            accuracy += f1_score(predictions[column][i],true_values[i])
+        else:
+            # For the T+1 usecase
+            print([x[0] for x in predictions[column]], ' ||| ', list(true_values), ' ||| ', len(list(true_values)), len(predictions[column]), len(([x[0] for x in predictions[column]])))
+            accuracy = f1_score([x[0] for x in predictions[column]], true_values)
+            break
+
+    accuracy = accuracy/len(predictions[column])
+    return accuracy
+
 
 def evaluate_accuracy(predictions, data_frame, col_stats, output_columns, backend=None, hmd=None):
     column_scores = []
     for column in output_columns:
         col_type = col_stats[column]['typing']['data_type']
         col_subtype = col_stats[column]['typing']['data_subtype']
+        print(col_type, col_subtype, column)
         if col_type == DATA_TYPES.NUMERIC:
             evaluator = evaluate_regression_accuracy
         elif col_type == DATA_TYPES.CATEGORICAL:
@@ -175,6 +190,8 @@ def evaluate_accuracy(predictions, data_frame, col_stats, output_columns, backen
                 evaluator = evaluate_multilabel_accuracy
             else:
                 evaluator = evaluate_classification_accuracy
+        elif col_type == DATA_TYPES.SEQUENTIAL:
+            evaluator = evaluate_array_accuracy
         else:
             evaluator = evaluate_generic_accuracy
         column_score = evaluator(column, predictions, data_frame[column], backend)

--- a/mindsdb_native/libs/helpers/general_helpers.py
+++ b/mindsdb_native/libs/helpers/general_helpers.py
@@ -170,7 +170,7 @@ def evaluate_array_accuracy(column, predictions, true_values, backend):
             accuracy += r2_score(predictions[column][i],true_values[i])
         else:
             # For the T+1 usecase
-            accuracy = r2_score([x[0] for x in predictions[column]], true_values)
+            accuracy = r2_score([x[0] for x in predictions[column]], true_values) #[float(x) for x in true_values]
             return accuracy
 
     accuracy = accuracy/len(predictions[column])

--- a/mindsdb_native/libs/helpers/general_helpers.py
+++ b/mindsdb_native/libs/helpers/general_helpers.py
@@ -170,7 +170,7 @@ def evaluate_array_accuracy(column, predictions, true_values, backend):
             accuracy += r2_score(predictions[column][i],true_values[i])
         else:
             # For the T+1 usecase
-            accuracy = r2_score([x[0] for x in predictions[column]], true_values) #[float(x) for x in true_values]
+            accuracy = r2_score([x[0] for x in predictions[column]], true_values)
             return accuracy
 
     accuracy = accuracy/len(predictions[column])

--- a/mindsdb_native/libs/phases/data_splitter/data_splitter.py
+++ b/mindsdb_native/libs/phases/data_splitter/data_splitter.py
@@ -89,6 +89,9 @@ class DataSplitter(BaseModule):
                 self.transaction.input_data.validation_df['make_predictions'] = [True] * len(self.transaction.input_data.validation_df)
                 self.transaction.input_data.validation_df = pd.concat([self.transaction.input_data.validation_df,historical_test,deepcopy(historical_train)])
 
+                self.transaction.input_data.clean_validation_df = self.transaction.input_data.validation_df[self.transaction.input_data.validation_df['make_predictions'] == True]
+            else:
+                self.transaction.input_data.clean_validation_df = self.transaction.input_data.validation_df
 
             self.transaction.input_data.data_frame = None
 

--- a/mindsdb_native/libs/phases/data_splitter/data_splitter.py
+++ b/mindsdb_native/libs/phases/data_splitter/data_splitter.py
@@ -89,10 +89,6 @@ class DataSplitter(BaseModule):
                 self.transaction.input_data.validation_df['make_predictions'] = [True] * len(self.transaction.input_data.validation_df)
                 self.transaction.input_data.validation_df = pd.concat([self.transaction.input_data.validation_df,historical_test,deepcopy(historical_train)])
 
-                self.transaction.input_data.clean_validation_df = self.transaction.input_data.validation_df[self.transaction.input_data.validation_df['make_predictions'] == True]
-            else:
-                self.transaction.input_data.clean_validation_df = self.transaction.input_data.validation_df
-
             self.transaction.input_data.data_frame = None
 
             self.transaction.lmd['data_preparation']['test_row_count'] = len(self.transaction.input_data.test_df)

--- a/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
+++ b/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
@@ -29,7 +29,7 @@ class ModelAnalyzer(BaseModule):
 
         test_df = self.transaction.input_data.test_df
         if self.transaction.lmd['tss']['is_timeseries']:
-            validation_df = self.transaction.input_data.test_df[self.transaction.input_data.test_df['make_predictions'] == True]
+            test_df = self.transaction.input_data.test_df[self.transaction.input_data.test_df['make_predictions'] == True]
 
         output_columns = self.transaction.lmd['predict_columns']
         input_columns = [col for col in self.transaction.lmd['columns'] if col not in output_columns and col not in self.transaction.lmd['columns_to_ignore']]

--- a/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
+++ b/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
@@ -39,10 +39,7 @@ class ModelAnalyzer(BaseModule):
         )
 
         for col in output_columns:
-            if self.transaction.lmd['tss']['is_timeseries']:
-                reals = list(self.transaction.input_data.validation_df[self.transaction.input_data.validation_df['make_predictions'] == True][col])
-            else:
-                reals = self.transaction.input_data.validation_df[col]
+            reals = self.transaction.input_data.clean_validation_df[col]
             preds = normal_predictions[col]
 
             fails = False
@@ -83,7 +80,7 @@ class ModelAnalyzer(BaseModule):
             empty_input_predictions_test[col] = self.transaction.model_backend.predict('test', ignore_columns=[col])
             empty_input_accuracy[col] = evaluate_accuracy(
                 empty_input_predictions[col],
-                self.transaction.input_data.validation_df,
+                self.transaction.input_data.clean_validation_df,
                 self.transaction.lmd['stats_v2'],
                 output_columns,
                 backend=self.transaction.model_backend
@@ -143,7 +140,7 @@ class ModelAnalyzer(BaseModule):
             )
             self.transaction.lmd['valid_data_accuracy'][col] = evaluate_accuracy(
                 predictions,
-                self.transaction.input_data.validation_df,
+                self.transaction.input_data.clean_validation_df,
                 self.transaction.lmd['stats_v2'],
                 [col],
                 backend=self.transaction.model_backend
@@ -225,7 +222,7 @@ class ModelAnalyzer(BaseModule):
                 self.transaction.hmd['icp']['active'] = True
 
                 # calibrate conformal estimator on test set
-                X = deepcopy(self.transaction.input_data.validation_df)
+                X = deepcopy(self.transaction.input_data.clean_validation_df)
                 y = X.pop(target).values
 
                 if is_classification:

--- a/tests/unit_tests/libs/controllers/test_predictor.py
+++ b/tests/unit_tests/libs/controllers/test_predictor.py
@@ -433,57 +433,6 @@ class TestPredictor:
         assert (a2['existing_credits']['typing'][
                     'data_subtype'] == DATA_SUBTYPES.SINGLE)
 
-    #@pytest.mark.slow
-    def test_timeseries(self, tmp_path):
-        ts_hours = 12
-        data_len = 120
-        train_file_name = os.path.join(str(tmp_path), 'train_data.csv')
-        test_file_name = os.path.join(str(tmp_path), 'test_data.csv')
-
-        features = generate_value_cols(['date', 'int'], data_len, ts_hours * 3600)
-        labels = [generate_timeseries_labels(features)]
-
-        feature_headers = list(map(lambda col: col[0], features))
-        label_headers = list(map(lambda col: col[0], labels))
-
-        # Create the training dataset and save it to a file
-        columns_train = list(
-            map(lambda col: col[1:int(len(col) * 3 / 4)], features))
-        columns_train.extend(
-            list(map(lambda col: col[1:int(len(col) * 3 / 4)], labels)))
-        columns_to_file(columns_train, train_file_name, headers=[*feature_headers,
-                                                                 *label_headers])
-        # Create the testing dataset and save it to a file
-        columns_test = list(
-            map(lambda col: col[int(len(col) * 3 / 4):], features))
-        columns_to_file(columns_test, test_file_name, headers=feature_headers)
-
-        mdb = Predictor(name='test_timeseries')
-
-        mdb.learn(
-            from_data=train_file_name,
-            to_predict=label_headers,
-            timeseries_settings={
-                'order_by': [feature_headers[0]]
-                ,'window': 3
-            },
-            stop_training_in_x_seconds=10,
-            use_gpu=False,
-            advanced_args={'force_predict': True}
-        )
-
-        results = mdb.predict(when_data=test_file_name, use_gpu=False)
-
-        for row in results:
-            expect_columns = [label_headers[0],
-                              label_headers[0] + '_confidence']
-            for col in expect_columns:
-                assert col in row
-
-        models = F.get_models()
-        model_data = F.get_model_data(models[0]['name'])
-        assert model_data
-
     def test_multilabel_prediction(self, tmp_path):
         train_file_name = os.path.join(str(tmp_path), 'train_data.csv')
         test_file_name = os.path.join(str(tmp_path), 'test_data.csv')

--- a/tests/unit_tests/libs/controllers/test_predictor_timeseries.py
+++ b/tests/unit_tests/libs/controllers/test_predictor_timeseries.py
@@ -1,0 +1,132 @@
+import json
+import random
+from unittest import mock
+
+import pytest
+import os
+import numpy as np
+import pandas as pd
+from datetime import datetime, timedelta
+
+import torch
+from sklearn import preprocessing
+from sklearn.linear_model import LinearRegression
+from sklearn.metrics import r2_score, f1_score, accuracy_score
+
+from mindsdb_native.libs.controllers.predictor import Predictor
+from mindsdb_native import F
+
+from mindsdb_native.libs.data_sources.file_ds import FileDS
+from mindsdb_native.libs.constants.mindsdb import DATA_TYPES, DATA_SUBTYPES
+
+from unit_tests.utils import (test_column_types,
+                            generate_value_cols,
+                            generate_timeseries_labels,
+                            generate_log_labels,
+                            columns_to_file,
+                            PickableMock,
+                            SMALL_VOCAB)
+
+from mindsdb_native.libs.helpers.stats_helpers import sample_data
+
+
+class TestPredictorTimeseries:
+    @pytest.mark.slow
+    def test_timeseries(self, tmp_path):
+        ts_hours = 12
+        data_len = 120
+        train_file_name = os.path.join(str(tmp_path), 'train_data.csv')
+        test_file_name = os.path.join(str(tmp_path), 'test_data.csv')
+
+        features = generate_value_cols(['date', 'int'], data_len, ts_hours * 3600)
+        labels = [generate_timeseries_labels(features)]
+
+        feature_headers = list(map(lambda col: col[0], features))
+        label_headers = list(map(lambda col: col[0], labels))
+
+        # Create the training dataset and save it to a file
+        columns_train = list(
+            map(lambda col: col[1:int(len(col) * 3 / 4)], features))
+        columns_train.extend(
+            list(map(lambda col: col[1:int(len(col) * 3 / 4)], labels)))
+        columns_to_file(columns_train, train_file_name, headers=[*feature_headers,
+                                                                 *label_headers])
+        # Create the testing dataset and save it to a file
+        columns_test = list(
+            map(lambda col: col[int(len(col) * 3 / 4):], features))
+        columns_to_file(columns_test, test_file_name, headers=feature_headers)
+
+        mdb = Predictor(name='test_timeseries')
+
+        mdb.learn(
+            from_data=train_file_name,
+            to_predict=label_headers,
+            timeseries_settings={
+                'order_by': [feature_headers[0]]
+                ,'window': 3
+            },
+            stop_training_in_x_seconds=10,
+            use_gpu=False,
+            advanced_args={'force_predict': True}
+        )
+
+        results = mdb.predict(when_data=test_file_name, use_gpu=False)
+
+        for row in results:
+            expect_columns = [label_headers[0],
+                              label_headers[0] + '_confidence']
+            for col in expect_columns:
+                assert col in row
+
+        models = F.get_models()
+        model_data = F.get_model_data(models[0]['name'])
+        assert model_data
+
+
+    #@pytest.mark.slow
+    def test_timeseries_stepahead(self, tmp_path):
+        ts_hours = 12
+        data_len = 120
+        train_file_name = os.path.join(str(tmp_path), 'train_data.csv')
+        test_file_name = os.path.join(str(tmp_path), 'test_data.csv')
+
+        features = generate_value_cols(['date', 'int'], data_len, ts_hours * 3600)
+        labels = [generate_timeseries_labels(features)]
+
+        feature_headers = list(map(lambda col: col[0], features))
+        label_headers = list(map(lambda col: col[0], labels))
+
+        # Create the training dataset and save it to a file
+        columns_train = list(
+            map(lambda col: col[1:int(len(col) * 3 / 4)], features))
+        columns_train.extend(
+            list(map(lambda col: col[1:int(len(col) * 3 / 4)], labels)))
+        columns_to_file(columns_train, train_file_name, headers=[*feature_headers,
+                                                                 *label_headers])
+        # Create the testing dataset and save it to a file
+        columns_test = list(
+            map(lambda col: col[int(len(col) * 3 / 4):], features))
+        columns_to_file(columns_test, test_file_name, headers=feature_headers)
+
+        mdb = Predictor(name='test_timeseries')
+
+        mdb.learn(
+            from_data=train_file_name,
+            to_predict=label_headers,
+            timeseries_settings={
+                'order_by': [feature_headers[0]]
+                ,'window': 3
+                ,'nr_predictions': 6
+            },
+            stop_training_in_x_seconds=10,
+            use_gpu=False,
+            advanced_args={'force_predict': True}
+        )
+
+        results = mdb.predict(when_data=test_file_name, use_gpu=False)
+
+        for row in results:
+            assert label_headers[0] + '_confidence' in row
+            assert label_headers[0] in row
+            assert isinstance(row[label_headers[0]], list)
+            assert len(row[label_headers[0]]) == 6

--- a/tests/unit_tests/libs/controllers/test_predictor_timeseries.py
+++ b/tests/unit_tests/libs/controllers/test_predictor_timeseries.py
@@ -83,7 +83,7 @@ class TestPredictorTimeseries:
         assert model_data
 
 
-    #@pytest.mark.slow
+    @pytest.mark.slow
     def test_timeseries_stepahead(self, tmp_path):
         ts_hours = 12
         data_len = 120

--- a/tests/unit_tests/libs/helpers/test_general_helpers.py
+++ b/tests/unit_tests/libs/helpers/test_general_helpers.py
@@ -71,11 +71,38 @@ class TestEvaluateAccuracy:
 
         assert round(accuracy, 2) == round((0.75 + 0.5)/2, 2)
 
+    def test_evaluate_array(self):
+        predictions = {
+            'y': [[1], [2], [3], [4]]
+        }
+
+        col_stats = {
+            'y': {'typing': {'data_type': DATA_TYPES.SEQUENTIAL,
+                             'data_subtype': DATA_SUBTYPES.ARRAY}}
+        }
+
+        output_columns = ['y']
+
+        data_frame = pd.DataFrame({'y': [1, 2, 3, 5]})
+
+        accuracy = evaluate_accuracy(predictions, data_frame, col_stats,
+                                     output_columns)
+
+        assert round(accuracy, 2) == 0.8
+
+        predictions = {
+            'y': [[1, 2, 3, 4], [2, 3, 4, 5]]
+        }
+        data_frame = pd.DataFrame({'y': [[1, 2, 3, 5], [2, 3, 4, 6]]})
+
+        accuracy = evaluate_accuracy(predictions, data_frame, col_stats, output_columns)
+
+        assert round(accuracy, 2)  == 0.8
+
     def test_evaluate_weird_data_types(self):
         for dtype, data_subtype in [
             (DATA_TYPES.DATE, DATA_SUBTYPES.DATE),
             (DATA_TYPES.TEXT, DATA_SUBTYPES.SHORT),
-            (DATA_TYPES.SEQUENTIAL, DATA_SUBTYPES.ARRAY),
             (DATA_TYPES.FILE_PATH, None)
         ]:
             predictions = {


### PR DESCRIPTION
Added a way (hack) to predict `n` timesteps ahead using mindsdb_native for timeseries problems, also added a way for the `ModelAnalyzer` and the backend choosing mechanism to handle array outputs (useful for when we want to predict arrays of all kinds).

Also simplified the way the ModelAnalyzer and lightwood backend deal with historical data (for timeseries problems, that is).

Also:

* Separate timeseries tests
* Improved the way confidences are sourced from lightwood
* Added test for predicting 6 timesteps ahead