### PR TITLE
add debug flag, allow models fail

### DIFF
--- a/mindsdb_native/libs/backends/lightwood.py
+++ b/mindsdb_native/libs/backends/lightwood.py
@@ -380,6 +380,9 @@ class LightwoodBackend():
                 validation_accuracy
             ))
 
+        if len(predictors_and_accuracies) == 0:
+            raise Exception('All models failed')
+
         best_predictor, best_accuracy = max(predictors_and_accuracies, key=lambda x: x[1])
 
         # Find predictor with NnMixer

--- a/mindsdb_native/libs/backends/lightwood.py
+++ b/mindsdb_native/libs/backends/lightwood.py
@@ -344,10 +344,17 @@ class LightwoodBackend():
 
             self.predictor = lightwood.Predictor(lightwood_config.copy())
 
-            self.predictor.learn(
-                from_data=lightwood_train_ds,
-                test_data=lightwood_test_ds
-            )
+            try:
+                self.predictor.learn(
+                    from_data=lightwood_train_ds,
+                    test_data=lightwood_test_ds
+                )
+            except Exception:
+                if self.transaction.lmd['debug']:
+                    raise
+                else:
+                    self.transaction.log.error('Exception while running {}'.format(mixer_class.__name__))
+                    continue
 
             self.transaction.log.info('[{}] Training accuracy of: {}'.format(
                 mixer_class.__name__,

--- a/mindsdb_native/libs/controllers/predictor.py
+++ b/mindsdb_native/libs/controllers/predictor.py
@@ -248,7 +248,8 @@ class Predictor:
                 tags_delimiter = advanced_args.get('tags_delimiter', ','),
                 force_predict = advanced_args.get('force_predict', False),
                 mixer_class = advanced_args.get('use_mixers', None),
-                setup_args = from_data.setup_args if hasattr(from_data, 'setup_args') else None
+                setup_args = from_data.setup_args if hasattr(from_data, 'setup_args') else None,
+                debug = advanced_args.get('debug', False)
             )
 
             if rebuild_model is False:


### PR DESCRIPTION
https://github.com/mindsdb/mindsdb_native/issues/217

- add `debug` flag in `advanced_args` (`False` by default)
- dont't crash if a single model fails to train and `debug=False`