### PR TITLE
Don't drop foreign key if it's in order_by

### DIFF
--- a/mindsdb_native/libs/helpers/text_helpers.py
+++ b/mindsdb_native/libs/helpers/text_helpers.py
@@ -182,7 +182,6 @@ def get_pct_auto_increment(data):
             pass
 
     int_data = sorted(int_data)
-    print(int_data)
     prev_nr = int_data[0]
     increase_by_one = 0
     for nr in int_data[1:]:

--- a/mindsdb_native/libs/phases/type_deductor/type_deductor.py
+++ b/mindsdb_native/libs/phases/type_deductor/type_deductor.py
@@ -328,13 +328,13 @@ class TypeDeductor(BaseModule):
             if stats_v2[col_name]['identifier'] is not None:
 
                 if col_name not in self.transaction.lmd['force_column_usage']:
-
-                    if (self.transaction.lmd['tss']['is_timeseries'] and
-                            col_name in self.transaction.lmd['tss']['order_by']):
-                        pass
-
-                    elif col_name not in self.transaction.lmd['predict_columns']:
-                        self.transaction.lmd['columns_to_ignore'].append(col_name)
+                    if col_name not in self.transaction.lmd['predict_columns']:
+                        if (self.transaction.lmd.get('tss', None) and
+                                self.transaction.lmd['tss']['is_timeseries'] and
+                                col_name in self.transaction.lmd['tss']['order_by']):
+                            pass
+                        else:
+                            self.transaction.lmd['columns_to_ignore'].append(col_name)
 
             if data_subtype_dist:
                 self.log.info(f'Data distribution for column "{col_name}" '

--- a/mindsdb_native/libs/phases/type_deductor/type_deductor.py
+++ b/mindsdb_native/libs/phases/type_deductor/type_deductor.py
@@ -326,8 +326,14 @@ class TypeDeductor(BaseModule):
             )
 
             if stats_v2[col_name]['identifier'] is not None:
+
                 if col_name not in self.transaction.lmd['force_column_usage']:
-                    if col_name not in self.transaction.lmd['predict_columns']:
+
+                    if (self.transaction.lmd['tss']['is_timeseries'] and
+                            col_name in self.transaction.lmd['tss']['order_by']):
+                        pass
+
+                    elif col_name not in self.transaction.lmd['predict_columns']:
                         self.transaction.lmd['columns_to_ignore'].append(col_name)
 
             if data_subtype_dist:

--- a/tests/unit_tests/libs/controllers/test_predictor_timeseries.py
+++ b/tests/unit_tests/libs/controllers/test_predictor_timeseries.py
@@ -22,6 +22,7 @@ from mindsdb_native.libs.constants.mindsdb import DATA_TYPES, DATA_SUBTYPES
 from unit_tests.utils import (test_column_types,
                             generate_value_cols,
                             generate_timeseries_labels,
+                            generate_timeseries,
                             generate_log_labels,
                             columns_to_file,
                             PickableMock,
@@ -130,3 +131,47 @@ class TestPredictorTimeseries:
             assert label_headers[0] in row
             assert isinstance(row[label_headers[0]], list)
             assert len(row[label_headers[0]]) == 6
+
+    def test_keep_id_orderby(self, tmp_path):
+        data_len = 100
+        train_file_name = os.path.join(str(tmp_path), 'train_data.csv')
+        test_file_name = os.path.join(str(tmp_path), 'test_data.csv')
+        col_name = 'id'
+
+        features = [generate_timeseries(data_len, period=1)]
+        features[0].insert(0, col_name)
+        labels = [[str(random.randint(0, 1)) for _ in range(len(features[0][1:]))]]
+        labels[0].insert(0, 'Y')
+
+        feature_headers = list(map(lambda col: col[0], features))
+        label_headers = list(map(lambda col: col[0], labels))
+
+        # Create the training dataset and save it to a file
+        columns_train = list(
+            map(lambda col: col[1:int(len(col) * 3 / 4)], features))
+        columns_train.extend(
+            list(map(lambda col: col[1:int(len(col) * 3 / 4)], labels)))
+        columns_to_file(columns_train, train_file_name, headers=[*feature_headers,
+                                                                 *label_headers])
+        # Create the testing dataset and save it to a file
+        columns_test = list(
+            map(lambda col: col[int(len(col) * 3 / 4):], features))
+        columns_to_file(columns_test, test_file_name, headers=feature_headers)
+
+        mdb = Predictor(name='test_timeseries')
+
+        mdb.learn(
+            from_data=train_file_name,
+            to_predict=label_headers,
+            timeseries_settings={
+                'order_by': [feature_headers[0]]
+                , 'window': 2
+            },
+            stop_training_in_x_seconds=1,
+            use_gpu=False,
+            advanced_args={'force_predict': True}
+        )
+
+        admittable = ['Auto-incrementing identifier']
+        assert col_name not in mdb.transaction.lmd['columns_to_ignore']
+        assert mdb.transaction.lmd['stats_v2'][col_name]['identifier'] in admittable


### PR DESCRIPTION
While this fixes #239, I would like to benchmark a little more, to see whether this introduces any overfitting problems with the TS RNN encoder.