### PR TITLE
Flag for using database history

### DIFF
--- a/.github/workflows/mindsdb_native.yml
+++ b/.github/workflows/mindsdb_native.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - stable
       - staging
-      
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}
@@ -33,6 +33,8 @@ jobs:
       run: |
           pytest --run-slow --durations=20 tests/unit_tests
       shell: bash
+      env:
+        CHECK_FOR_UPDATES: False
     - name: Run integration tests
       run: |
         if [ "$RUNNER_OS" == "Linux" ]; then

--- a/mindsdb_native/libs/backends/lightwood.py
+++ b/mindsdb_native/libs/backends/lightwood.py
@@ -32,7 +32,7 @@ class LightwoodBackend():
 
         original_index_list = []
         idx = 0
-        for _, row in original_df.iterrows():
+        for row in original_df.itertuples():
             if _make_pred(row):
                 original_index_list.append(idx)
                 idx += 1
@@ -49,7 +49,7 @@ class LightwoodBackend():
                 secondary_type_dict[col] = ColumnDataTypes.NUMERIC
 
         # Convert order_by columns to numbers (note, rows are references to mutable rows in `original_df`)
-        for _, row in original_df.iterrows():
+        for row in original_df.itertuples():
             for col in ob_arr:
                 # @TODO: Remove if the TS encoder can handle `None`
                 if row[col] is None:
@@ -137,7 +137,7 @@ class LightwoodBackend():
 
         timeseries_row_mapping = {}
         idx = 0
-        for _, row in combined_df.iterrows():
+        for row in combined_df.itertuples():
             timeseries_row_mapping[idx] = int(row['original_index']) if row['original_index'] is not None and not np.isnan(row['original_index']) else None
             idx += 1
         del combined_df['original_index']

--- a/mindsdb_native/libs/backends/lightwood.py
+++ b/mindsdb_native/libs/backends/lightwood.py
@@ -15,7 +15,7 @@ from mindsdb_native.libs.helpers.stats_helpers import sample_data
 from mindsdb_native.libs.helpers.general_helpers import evaluate_accuracy
 
 def _make_pred(row):
-    return 'make_predictions' not in row or row['make_predictions'] == True
+    return not hasattr(row, "make_predictions") or row.make_predictions
 
 class LightwoodBackend():
 
@@ -32,7 +32,7 @@ class LightwoodBackend():
 
         original_index_list = []
         idx = 0
-        for _, row in original_df.iterrows():
+        for row in original_df.itertuples():
             if _make_pred(row):
                 original_index_list.append(idx)
                 idx += 1

--- a/mindsdb_native/libs/backends/lightwood.py
+++ b/mindsdb_native/libs/backends/lightwood.py
@@ -507,7 +507,7 @@ class LightwoodBackend():
             for k in list(formated_predictions.keys()):
                 ordered_values = [None] * len(formated_predictions[k])
                 for i, value in enumerate(formated_predictions[k]):
-                    ordered_values[[timeseries_row_mapping[i]] = valuje
+                    ordered_values[timeseries_row_mapping[i]] = value
                 formated_predictions[k] = ordered_values
 
         return formated_predictions

--- a/mindsdb_native/libs/backends/lightwood.py
+++ b/mindsdb_native/libs/backends/lightwood.py
@@ -73,7 +73,6 @@ class LightwoodBackend():
 
             ts_groups[tuple(row[group_by])].append(row)
             self.timeseries_row_mapping[i] = prev_group_len + group_current_length
-            timeseries_row_nullout.append(prev_group_len + group_current_length)
 
         # Convert each group to pandas.DataFrame
         for group in group_by_order_list:
@@ -109,6 +108,11 @@ class LightwoodBackend():
                             ts_groups[group][order_col].iloc[prev_i][-1]
                         )
 
+                    # Zero pad
+                    # @TODO: Remove since RNN encoder can do without (???)
+                    ts_groups[group].iloc[i][order_col].extend(
+                        [0] * (1 + window - len(ts_groups[group].iloc[i][order_col]))
+                    )
                     ts_groups[group].iloc[i][order_col].reverse()
 
         if self.transaction.lmd['tss']['use_previous_target']:

--- a/mindsdb_native/libs/backends/lightwood.py
+++ b/mindsdb_native/libs/backends/lightwood.py
@@ -77,7 +77,8 @@ class LightwoodBackend():
 
         # Make type `object` so that dataframe cells can be python lists
         for i in range(len(df_arr)):
-            df_arr[i] = df_arr[i].astype(object)
+            for hist_col in ob_arr + self.transaction.lmd['tss']['historical_columns']:
+                df_arr[i] = df_arr[i][hist_col].astype(object)
 
         # Make all order column cells lists
         for i in range(len(df_arr)):

--- a/mindsdb_native/libs/backends/lightwood.py
+++ b/mindsdb_native/libs/backends/lightwood.py
@@ -504,12 +504,11 @@ class LightwoodBackend():
             if 'confidence_range' in predictions[k]:
                 formated_predictions[f'{k}_confidence_range'] = predictions[k]['confidence_range']
 
-        if len(timeseries_row_mapping):
-            ordered_formated_predictions = {}
+        if self.transaction.lmd['tss']['is_timeseries']:
             for k in list(formated_predictions.keys()):
-                ordered_values = []
-                for i in timeseries_row_mapping:
-                    ordered_values.append(formated_predictions[k][timeseries_row_mapping[i]])
+                ordered_values = [None] * len(formated_predictions[k])
+                for i, value in enumerate(formated_predictions[k]):
+                    ordered_values[[timeseries_row_mapping[i]] = valuje
                 formated_predictions[k] = ordered_values
 
         return formated_predictions

--- a/mindsdb_native/libs/backends/lightwood.py
+++ b/mindsdb_native/libs/backends/lightwood.py
@@ -126,13 +126,16 @@ class LightwoodBackend():
                     # Remove rows without full historical data
                     # Don't do this if the `make_predictions` is explicitly specified
                     # Only really relevant for inference (predict) time
-                    if 'make_predictions' not in ts_groups[k]:
+                    print(ts_groups[k].keys())
+                    if 'make_predictions' not in ts_groups[k] and not self.transaction.lmd['allow_incomplete_history']:
                         # Pick and arbitrary order by column
                         idx = 0
                         while idx < len(ts_groups[k][order_by[0]]):
+                            print(f'At index: {idx}')
                             if len(ts_groups[k][order_by[0]]) < window:
                                 for col in list(ts_groups[k].keys()):
                                     del ts_groups[k][col][idx]
+                                    print(idx)
                             else:
                                 idx += 1
 

--- a/mindsdb_native/libs/backends/lightwood.py
+++ b/mindsdb_native/libs/backends/lightwood.py
@@ -32,7 +32,7 @@ class LightwoodBackend():
 
         original_index_list = []
         idx = 0
-        for row in original_df:
+        for _, row in original_df.iterrows():
             if _make_pred(row):
                 original_index_list.append(idx)
                 idx += 1
@@ -55,10 +55,13 @@ class LightwoodBackend():
                 if row[col] is None:
                     row[col] = 0.0
 
-                if self.transaction.lmd['stats_v2'][col]['typing']['data_type'] == DATA_TYPES.DATE:
-                    row[col] = float(row[col].timestamp())
                 try:
-                    float(row[col])
+                    row[col] = row[col].timestamp()
+                except Exception:
+                    pass
+                
+                try:
+                    row[col] = float(row[col])
                 except Exception:
                     err_msg = f
                     self.transaction.log.error(err_msg)

--- a/mindsdb_native/libs/backends/lightwood.py
+++ b/mindsdb_native/libs/backends/lightwood.py
@@ -525,7 +525,6 @@ class LightwoodBackend():
             for k in list(formated_predictions.keys()):
                 ordered_values = []
                 for i in timeseries_row_mapping:
-                    print(k, len(formated_predictions[k]))
                     ordered_values.append(formated_predictions[k][timeseries_row_mapping[i]])
                 formated_predictions[k] = ordered_values
 

--- a/mindsdb_native/libs/backends/lightwood.py
+++ b/mindsdb_native/libs/backends/lightwood.py
@@ -26,6 +26,7 @@ class LightwoodBackend():
         self.nn_mixer_only = False
 
     def _ts_reshape(self, original_df):
+        original_df = copy.deepcopy(original_df)
         gb_arr = self.transaction.lmd['tss']['group_by'] if self.transaction.lmd['tss']['group_by'] is not None else []
         ob_arr = self.transaction.lmd['tss']['order_by']
         window = self.transaction.lmd['tss']['window']
@@ -63,8 +64,6 @@ class LightwoodBackend():
                 try:
                     row[col] = float(row[col])
                 except Exception:
-                    err_msg = f
-                    self.transaction.log.error(err_msg)
                     raise ValueError(f'Failed to order based on column: "{col}" due to faulty value: {row[col]}')
 
         if len(gb_arr) > 0:
@@ -78,7 +77,7 @@ class LightwoodBackend():
         # Make type `object` so that dataframe cells can be python lists
         for i in range(len(df_arr)):
             for hist_col in ob_arr + self.transaction.lmd['tss']['historical_columns']:
-                df_arr[i] = df_arr[i][hist_col].astype(object)
+                df_arr[i][hist_col] = df_arr[i][hist_col].astype(object)
 
         # Make all order column cells lists
         for i in range(len(df_arr)):

--- a/mindsdb_native/libs/backends/lightwood.py
+++ b/mindsdb_native/libs/backends/lightwood.py
@@ -32,7 +32,7 @@ class LightwoodBackend():
 
         original_index_list = []
         idx = 0
-        for row in original_df.itertuples():
+        for _, row in original_df.iterrows():
             if _make_pred(row):
                 original_index_list.append(idx)
                 idx += 1
@@ -49,7 +49,7 @@ class LightwoodBackend():
                 secondary_type_dict[col] = ColumnDataTypes.NUMERIC
 
         # Convert order_by columns to numbers (note, rows are references to mutable rows in `original_df`)
-        for row in original_df.itertuples():
+        for _, row in original_df.iterrows():
             for col in ob_arr:
                 # @TODO: Remove if the TS encoder can handle `None`
                 if row[col] is None:
@@ -137,7 +137,7 @@ class LightwoodBackend():
 
         timeseries_row_mapping = {}
         idx = 0
-        for row in combined_df.itertuples():
+        for _, row in combined_df.iterrows():
             timeseries_row_mapping[idx] = int(row['original_index']) if row['original_index'] is not None and not np.isnan(row['original_index']) else None
             idx += 1
         del combined_df['original_index']

--- a/mindsdb_native/libs/backends/lightwood.py
+++ b/mindsdb_native/libs/backends/lightwood.py
@@ -130,7 +130,7 @@ class LightwoodBackend():
         combined_df = pd.concat(df_arr)
 
         timeseries_row_mapping = {}
-        for i, row in combined_df:
+        for i, row in combined_df.iterrows():
             timeseries_row_mapping[i] = row['original_index']
 
         del combined_df['original_index']

--- a/mindsdb_native/libs/backends/lightwood.py
+++ b/mindsdb_native/libs/backends/lightwood.py
@@ -57,7 +57,6 @@ class LightwoodBackend():
 
                 if self.transaction.lmd['stats_v2'][col]['typing']['data_type'] == DATA_TYPES.DATE:
                     row[col] = float(row[col].timestamp())
-:
                 try:
                     float(row[col])
                 except Exception:

--- a/mindsdb_native/libs/backends/lightwood.py
+++ b/mindsdb_native/libs/backends/lightwood.py
@@ -135,10 +135,12 @@ class LightwoodBackend():
             del combined_df['make_predictions']
 
         timeseries_row_mapping = {}
-        for i, row in combined_df.iterrows():
-            timeseries_row_mapping[i] = int(row['original_index']) if row['original_index'] is not None and not np.isnan(row['original_index']) else None
+        idx = 0
+        for _, row in combined_df.iterrows():
+            timeseries_row_mapping[idx] = int(row['original_index']) if row['original_index'] is not None and not np.isnan(row['original_index']) else None
+            idx += 1
         del combined_df['original_index']
-        
+
         if len(combined_df) == 0:
             raise Exception(f'Not enough historical context to make a timeseries prediction. Please provide a number of rows greater or equal to the window size. If you can\'t get enough rows, consider lowering your window size. If you want to force timeseries predictions lacking historical context please set the `allow_incomplete_history` advanced argument to `True`, but this might lead to subpar predictions.')
 
@@ -398,7 +400,6 @@ class LightwoodBackend():
             if self.transaction.lmd['tss']['is_timeseries']:
                 validation_df = self.transaction.input_data.validation_df[self.transaction.input_data.validation_df['make_predictions'] == True]
 
-            print(validation_predictions)
             validation_accuracy = evaluate_accuracy(
                 validation_predictions,
                 self.transaction.input_data.validation_df[self.transaction.input_data.validation_df['make_predictions'].astype(bool) == True] if self.transaction.lmd['tss']['is_timeseries'] else self.transaction.input_data.validation_df,
@@ -516,7 +517,6 @@ class LightwoodBackend():
                 ordered_values = [None] * len(formated_predictions[k])
                 for i, value in enumerate(formated_predictions[k]):
                     if timeseries_row_mapping[i] is not None:
-                        print(len(ordered_values), timeseries_row_mapping[i])
                         ordered_values[timeseries_row_mapping[i]] = value
                 formated_predictions[k] = ordered_values
 

--- a/mindsdb_native/libs/backends/lightwood.py
+++ b/mindsdb_native/libs/backends/lightwood.py
@@ -129,15 +129,16 @@ class LightwoodBackend():
 
         combined_df = pd.concat(df_arr)
 
-        timeseries_row_mapping = {}
-        for i, row in combined_df.iterrows():
-            timeseries_row_mapping[i] = row['original_index']
 
-        del combined_df['original_index']
         if 'make_predictions' in combined_df.columns:
             combined_df = pd.DataFrame(combined_df[combined_df['make_predictions'].astype(bool) == True])
             del combined_df['make_predictions']
 
+        timeseries_row_mapping = {}
+        for i, row in combined_df.iterrows():
+            timeseries_row_mapping[i] = int(row['original_index']) if row['original_index'] is not None and not np.isnan(row['original_index']) else None
+        del combined_df['original_index']
+        
         if len(combined_df) == 0:
             raise Exception(f'Not enough historical context to make a timeseries prediction. Please provide a number of rows greater or equal to the window size. If you can\'t get enough rows, consider lowering your window size. If you want to force timeseries predictions lacking historical context please set the `allow_incomplete_history` advanced argument to `True`, but this might lead to subpar predictions.')
 
@@ -397,6 +398,7 @@ class LightwoodBackend():
             if self.transaction.lmd['tss']['is_timeseries']:
                 validation_df = self.transaction.input_data.validation_df[self.transaction.input_data.validation_df['make_predictions'] == True]
 
+            print(validation_predictions)
             validation_accuracy = evaluate_accuracy(
                 validation_predictions,
                 self.transaction.input_data.validation_df[self.transaction.input_data.validation_df['make_predictions'].astype(bool) == True] if self.transaction.lmd['tss']['is_timeseries'] else self.transaction.input_data.validation_df,
@@ -513,7 +515,9 @@ class LightwoodBackend():
             for k in list(formated_predictions.keys()):
                 ordered_values = [None] * len(formated_predictions[k])
                 for i, value in enumerate(formated_predictions[k]):
-                    ordered_values[timeseries_row_mapping[i]] = value
+                    if timeseries_row_mapping[i] is not None:
+                        print(len(ordered_values), timeseries_row_mapping[i])
+                        ordered_values[timeseries_row_mapping[i]] = value
                 formated_predictions[k] = ordered_values
 
         return formated_predictions

--- a/mindsdb_native/libs/backends/lightwood.py
+++ b/mindsdb_native/libs/backends/lightwood.py
@@ -63,15 +63,19 @@ class LightwoodBackend():
         # Make groups
         ts_groups = defaultdict(list)
         for i, row in original_df.iterrows():
+            group_key = tuple(row[group_by])
             prev_group_len = 0
             for group in group_by_order_list:
+                if group == group_key:
+                    break
                 prev_group_len += group_len[group]
+
             try:
-                group_current_length = len(ts_groups[tuple(row[group_by])])
+                group_current_length = len(ts_groups[group_key])
             except:
                 group_current_length = 0
 
-            ts_groups[tuple(row[group_by])].append(row)
+            ts_groups[group_key].append(row)
             self.timeseries_row_mapping[i] = prev_group_len + group_current_length
 
         # Convert each group to pandas.DataFrame
@@ -516,12 +520,13 @@ class LightwoodBackend():
             if 'confidence_range' in predictions[k]:
                 formated_predictions[f'{k}_confidence_range'] = predictions[k]['confidence_range']
 
+        print(self.timeseries_row_mapping)
         if len(self.timeseries_row_mapping):
             ordered_formated_predictions = {}
             for k in list(formated_predictions.keys()):
                 ordered_values = []
-                for i in timeseries_row_mapping:
-                    ordered_values.append(formated_predictions[k][timeseries_row_mapping[i]])
+                for i in self.timeseries_row_mapping:
+                    ordered_values.append(formated_predictions[k][self.timeseries_row_mapping[i]])
                 formated_predictions[k] = ordered_values
 
         return formated_predictions

--- a/mindsdb_native/libs/controllers/predictor.py
+++ b/mindsdb_native/libs/controllers/predictor.py
@@ -68,8 +68,7 @@ def _prepare_timeseries_settings(user_provided_settings):
     if len(user_provided_settings) > 0:
         if 'order_by' not in user_provided_settings:
             raise Exception('Invalid timeseries settings, please provide `order_by` key [a list of columns]')
-
-        elif 'window' not in user_provided_settings
+        elif 'window' not in user_provided_settings:
             raise Exception(f'Invalid timeseries settings, you must specify a window size')
         else:
             timeseries_settings['is_timeseries'] = True

--- a/mindsdb_native/libs/controllers/predictor.py
+++ b/mindsdb_native/libs/controllers/predictor.py
@@ -64,7 +64,6 @@ def _prepare_timeseries_settings(user_provided_settings):
         ,keep_order_column=True
         ,nr_predictions=1
         ,historical_columns=[]
-        ,use_database_history=True
     )
 
     if len(user_provided_settings) > 0:
@@ -250,7 +249,8 @@ class Predictor:
                 force_predict = advanced_args.get('force_predict', False),
                 mixer_class = advanced_args.get('use_mixers', None),
                 setup_args = from_data.setup_args if hasattr(from_data, 'setup_args') else None,
-                debug = advanced_args.get('debug', False)
+                debug = advanced_args.get('debug', False),
+                allow_incomplete_history = advanced_args.get('allow_incomplete_history', False)
             )
 
             if rebuild_model is False:
@@ -374,7 +374,9 @@ class Predictor:
                 use_gpu = use_gpu,
                 data_preparation = {},
                 run_confidence_variation_analysis = run_confidence_variation_analysis,
-                force_disable_cache = advanced_args.get('force_disable_cache', disable_lightwood_transform_cache)
+                force_disable_cache = advanced_args.get('force_disable_cache', disable_lightwood_transform_cache),
+                use_database_history = advanced_args.get('use_database_history', False),
+                allow_incomplete_history = advanced_args.get('allow_incomplete_history', False)
             )
 
             self.transaction = PredictTransaction(

--- a/mindsdb_native/libs/controllers/predictor.py
+++ b/mindsdb_native/libs/controllers/predictor.py
@@ -64,6 +64,7 @@ def _prepare_timeseries_settings(user_provided_settings):
         ,keep_order_column=True
         ,nr_predictions=1
         ,historical_columns=[]
+        ,use_database_history=True
     )
 
     if len(user_provided_settings) > 0:

--- a/mindsdb_native/libs/controllers/predictor.py
+++ b/mindsdb_native/libs/controllers/predictor.py
@@ -60,7 +60,6 @@ def _prepare_timeseries_settings(user_provided_settings):
         ,order_by=None
         ,window=None
         ,use_previous_target=True
-        ,keep_order_column=True
         ,nr_predictions=1
         ,historical_columns=[]
     )

--- a/mindsdb_native/libs/controllers/predictor.py
+++ b/mindsdb_native/libs/controllers/predictor.py
@@ -59,7 +59,6 @@ def _prepare_timeseries_settings(user_provided_settings):
         ,group_by=None
         ,order_by=None
         ,window=None
-        ,dynamic_window=None
         ,use_previous_target=True
         ,keep_order_column=True
         ,nr_predictions=1
@@ -70,11 +69,8 @@ def _prepare_timeseries_settings(user_provided_settings):
         if 'order_by' not in user_provided_settings:
             raise Exception('Invalid timeseries settings, please provide `order_by` key [a list of columns]')
 
-        elif 'window' not in user_provided_settings and 'dynamic_window' not in user_provided_settings:
-            raise Exception(f'Invalid timeseries settings, you must specify a window size with either `window` or `dynamic_window` key')
-
-        elif 'window' in user_provided_settings and 'dynamic_window' in user_provided_settings:
-            raise Exception(f'Invalid timeseries settings, you must specify a window size with *EITHER* `window` or `dynamic_window` key, not both!')
+        elif 'window' not in user_provided_settings
+            raise Exception(f'Invalid timeseries settings, you must specify a window size')
         else:
             timeseries_settings['is_timeseries'] = True
 

--- a/mindsdb_native/libs/helpers/query_composer.py
+++ b/mindsdb_native/libs/helpers/query_composer.py
@@ -55,7 +55,7 @@ def create_history_query(query, tss, stats, row):
                 query = split_query[0] + f' WHERE {merged_filter} GROUP BY ' + split_query[1]
             else:
                 query += f' WHERE {merged_filter}'
-                
+
         elif ' having ' in query:
             split_query = query.split(' group by ')
             if len(split_query) > 2:
@@ -79,11 +79,8 @@ def create_history_query(query, tss, stats, row):
         query += f' ORDER BY {order_by_list} DESC'
 
     # parse and append limit
-    if 'window' in tss:
-        limit = tss['window']
-        #query += f' LIMIT 1,{limit}' <--- if we assume the last row is the one we are predicting from
-        query += f' LIMIT {limit}'
-    else:
-        raise NotImplementedError('Historical queries not yet supported for `dynamic_window`')
+    limit = tss['window']
+    #query += f' LIMIT 1,{limit}' <--- if we assume the last row is the one we are predicting from
+    query += f' LIMIT {limit}'
 
     return query

--- a/mindsdb_native/libs/phases/data_extractor/data_extractor.py
+++ b/mindsdb_native/libs/phases/data_extractor/data_extractor.py
@@ -91,7 +91,8 @@ class DataExtractor(BaseModule):
                 # if no data frame yet, make one
                 df = self._data_from_when()
 
-            if self.transaction.lmd['setup_args'] is not None and self.transaction.lmd['tss']['is_timeseries'] and self.transaction.lmd['tss']['use_database_history']:
+            if self.transaction.lmd['setup_args'] is not None and self.transaction.lmd['tss']['is_timeseries'] and self.transaction.lmd['use_database_history']:
+                self.log.warning('Using automatic database history sourcing, will be selecting rows from the same table you used to train the original model.')
                 if 'make_predictions' not in df.columns:
                     df['make_predictions'] = [True] * len(df)
 

--- a/mindsdb_native/libs/phases/data_extractor/data_extractor.py
+++ b/mindsdb_native/libs/phases/data_extractor/data_extractor.py
@@ -91,7 +91,7 @@ class DataExtractor(BaseModule):
                 # if no data frame yet, make one
                 df = self._data_from_when()
 
-            if self.transaction.lmd['setup_args'] is not None and self.transaction.lmd['tss']['is_timeseries']:
+            if self.transaction.lmd['setup_args'] is not None and self.transaction.lmd['tss']['is_timeseries'] and self.transaction.lmd['tss']['use_database_history']:
                 if 'make_predictions' not in df.columns:
                     df['make_predictions'] = [True] * len(df)
 

--- a/mindsdb_native/libs/phases/data_extractor/data_extractor.py
+++ b/mindsdb_native/libs/phases/data_extractor/data_extractor.py
@@ -129,7 +129,9 @@ class DataExtractor(BaseModule):
 
                 df = pd.concat([df,historical_df])
 
-        df = self._apply_sort_conditions_to_df(df)
+        # Sorting here *should* only be needed at learn time
+        if self.transaction.lmd['type'] == TRANSACTION_LEARN:
+            df = self._apply_sort_conditions_to_df(df)
 
         # Mutable lists -> immutable tuples
         # (lists caused TypeError: uhashable type 'list' in TypeDeductor phase)

--- a/mindsdb_native/libs/phases/data_extractor/data_extractor.py
+++ b/mindsdb_native/libs/phases/data_extractor/data_extractor.py
@@ -57,7 +57,7 @@ class DataExtractor(BaseModule):
         if self.transaction.lmd['tss']['is_timeseries']:
             asc_values = [True for _ in self.transaction.lmd['tss']['order_by']]
             sort_by = self.transaction.lmd['tss']['order_by']
-            
+
             if self.transaction.lmd['tss']['group_by'] is not None:
                 sort_by = self.transaction.lmd['tss']['group_by'] + sort_by
                 asc_values = [True for _ in self.transaction.lmd['tss']['group_by']] + asc_values
@@ -65,7 +65,7 @@ class DataExtractor(BaseModule):
             df = df.sort_values(sort_by, ascending=asc_values)
 
         # if its not a time series, randomize the input data and we are learning
-        elif self.transaction.lmd['type'] == TRANSACTION_LEARN:
+        if not self.transaction.lmd['tss']['is_timeseries'] and self.transaction.lmd['type'] == TRANSACTION_LEARN:
             df = df.sample(frac=1, random_state=len(df))
 
         return df

--- a/mindsdb_native/libs/phases/data_extractor/data_extractor.py
+++ b/mindsdb_native/libs/phases/data_extractor/data_extractor.py
@@ -57,7 +57,7 @@ class DataExtractor(BaseModule):
         if self.transaction.lmd['tss']['is_timeseries']:
             asc_values = [True for _ in self.transaction.lmd['tss']['order_by']]
             sort_by = self.transaction.lmd['tss']['order_by']
-
+            
             if self.transaction.lmd['tss']['group_by'] is not None:
                 sort_by = self.transaction.lmd['tss']['group_by'] + sort_by
                 asc_values = [True for _ in self.transaction.lmd['tss']['group_by']] + asc_values

--- a/mindsdb_native/libs/phases/data_splitter/data_splitter.py
+++ b/mindsdb_native/libs/phases/data_splitter/data_splitter.py
@@ -83,6 +83,8 @@ class DataSplitter(BaseModule):
                 historical_test = deepcopy(self.transaction.input_data.test_df)
                 historical_test['make_predictions'] = [False] * len(historical_test)
 
+                self.transaction.input_data.train_df['make_predictions'] = [True] * len(self.transaction.input_data.train_df)
+
                 self.transaction.input_data.test_df['make_predictions'] = [True] * len(self.transaction.input_data.test_df)
                 self.transaction.input_data.test_df = pd.concat([self.transaction.input_data.test_df,historical_train])
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 psutil>=5.7.0
-lightwood == 0.44.0
+lightwood == 0.45.0
 cython >= 0.29.2
 setuptools >= 21.2.1
 wheel >= 0.32.2

--- a/tests/integration_tests/timeseries/database_history.py
+++ b/tests/integration_tests/timeseries/database_history.py
@@ -50,4 +50,4 @@ def test_database_history():
     ts_predictor.predict(when_data={
         'col2': 800
         ,'col1': '2'
-    })
+    }, advanced_args={'use_database_history': True})

--- a/tests/integration_tests/timeseries/database_history.py
+++ b/tests/integration_tests/timeseries/database_history.py
@@ -47,7 +47,9 @@ def test_database_history():
 
 
     ts_predictor = mindsdb_native.Predictor(name='query_history_based_ts_predictor')
-    ts_predictor.predict(when_data={
+    predictions = ts_predictor.predict(when_data={
         'col2': 800
         ,'col1': '2'
     }, advanced_args={'use_database_history': True})
+
+    assert predictions[0]['col3'] is not None

--- a/tests/unit_tests/libs/controllers/test_predictor_timeseries.py
+++ b/tests/unit_tests/libs/controllers/test_predictor_timeseries.py
@@ -231,7 +231,6 @@ class TestPredictorTimeseries:
         results = mdb.predict(when_data=test_file_name, use_gpu=False)
 
         for i, row in enumerate(results):
-            print(row['order_ai_id'], row['3_valued_group_by'], columns_test[2][i], columns_test[3][i])
             # Need to somehow test the internal ordering here (??)
             assert str(row['order_ai_id']) == str(columns_test[2][i])
             assert str(row['3_valued_group_by']) == str(columns_test[3][i])

--- a/tests/unit_tests/libs/controllers/test_predictor_timeseries.py
+++ b/tests/unit_tests/libs/controllers/test_predictor_timeseries.py
@@ -181,3 +181,56 @@ class TestPredictorTimeseries:
         admittable = ['Auto-incrementing identifier']
         assert col_name not in mdb.transaction.lmd['columns_to_ignore']
         assert mdb.transaction.lmd['stats_v2'][col_name]['identifier'] in admittable
+
+    @pytest.mark.slow
+    def test_keep_order(self, tmp_path):
+        ts_hours = 12
+        data_len = 120
+        train_file_name = os.path.join(str(tmp_path), 'train_data.csv')
+        test_file_name = os.path.join(str(tmp_path), 'test_data.csv')
+
+        features = generate_value_cols(['date', 'int'], data_len, ts_hours * 3600)
+        labels = [generate_timeseries_labels(features)]
+
+        feature_headers = list(map(lambda col: col[0], features))
+        label_headers = list(map(lambda col: col[0], labels))
+
+        features.append([x for x in range(data_len)])
+        features.append([x % 3 for x in range(data_len)])
+        feature_headers.append('order_ai_id')
+        feature_headers.append('3_valued_group_by')
+
+        # Create the training dataset and save it to a file
+        columns_train = list(
+            map(lambda col: col[1:int(len(col) * 3 / 4)], features))
+        columns_train.extend(
+            list(map(lambda col: col[1:int(len(col) * 3 / 4)], labels)))
+        columns_to_file(columns_train, train_file_name, headers=[*feature_headers,
+                                                                 *label_headers])
+        # Create the testing dataset and save it to a file
+        columns_test = list(
+            map(lambda col: col[int(len(col) * 3 / 4):], features))
+        columns_to_file(columns_test, test_file_name, headers=feature_headers)
+
+        mdb = Predictor(name='test_timeseries')
+
+        mdb.learn(
+            from_data=train_file_name,
+            to_predict=label_headers,
+            timeseries_settings={
+                'order_by': ['order_ai_id']
+                ,'window': 3
+                ,'nr_predictions': 6
+                ,'group_by': '3_valued_group_by'
+            },
+            stop_training_in_x_seconds=10,
+            use_gpu=False,
+            advanced_args={'force_predict': True}
+        )
+
+        results = mdb.predict(when_data=test_file_name, use_gpu=False)
+
+        for i, row in enumerate(results):
+            # Need to somehow test the internal ordering here (??)
+            assert row['order_ai_id'] == features[2][i]
+            assert row['3_valued_group_by'] == features[3][i]

--- a/tests/unit_tests/libs/controllers/test_predictor_timeseries.py
+++ b/tests/unit_tests/libs/controllers/test_predictor_timeseries.py
@@ -74,7 +74,6 @@ class TestPredictorTimeseries:
         results = mdb.predict(when_data=test_file_name, use_gpu=False)
 
         # Results should only be given for the rows with full history
-        print(results)
         assert len(results) == len(columns_test[-1])
         for row in results:
             expect_columns = [label_headers[0],

--- a/tests/unit_tests/libs/controllers/test_predictor_timeseries.py
+++ b/tests/unit_tests/libs/controllers/test_predictor_timeseries.py
@@ -75,7 +75,7 @@ class TestPredictorTimeseries:
 
         # Results should only be given for the rows with full history
         print(results)
-        assert len(results) == len(columns_test[-1]) - 2
+        assert len(results) == len(columns_test[-1])
         for row in results:
             expect_columns = [label_headers[0],
                               label_headers[0] + '_confidence']
@@ -130,7 +130,7 @@ class TestPredictorTimeseries:
         results = mdb.predict(when_data=test_file_name, use_gpu=False)
 
         # Results should only be given for the rows with full history
-        assert len(results) == len(columns_test[-1]) - 2
+        assert len(results) == len(columns_test[-1])
 
         for row in results:
             assert label_headers[0] + '_confidence' in row

--- a/tests/unit_tests/libs/controllers/test_predictor_timeseries.py
+++ b/tests/unit_tests/libs/controllers/test_predictor_timeseries.py
@@ -221,7 +221,7 @@ class TestPredictorTimeseries:
                 'order_by': ['order_ai_id']
                 ,'window': 3
                 ,'nr_predictions': 6
-                ,'group_by': '3_valued_group_by'
+                ,'group_by': ['3_valued_group_by']
             },
             stop_training_in_x_seconds=10,
             use_gpu=False,

--- a/tests/unit_tests/libs/controllers/test_predictor_timeseries.py
+++ b/tests/unit_tests/libs/controllers/test_predictor_timeseries.py
@@ -220,7 +220,7 @@ class TestPredictorTimeseries:
             timeseries_settings={
                 'order_by': ['order_ai_id']
                 ,'window': 3
-                ,'nr_predictions': 6
+                ,'nr_predictions': 1
                 ,'group_by': ['3_valued_group_by']
             },
             stop_training_in_x_seconds=10,
@@ -231,6 +231,7 @@ class TestPredictorTimeseries:
         results = mdb.predict(when_data=test_file_name, use_gpu=False)
 
         for i, row in enumerate(results):
+            print(row['order_ai_id'], row['3_valued_group_by'], columns_test[2][i], columns_test[3][i])
             # Need to somehow test the internal ordering here (??)
-            assert row['order_ai_id'] == features[2][i]
-            assert row['3_valued_group_by'] == features[3][i]
+            assert str(row['order_ai_id']) == str(columns_test[2][i])
+            assert str(row['3_valued_group_by']) == str(columns_test[3][i])

--- a/tests/unit_tests/libs/controllers/test_predictor_timeseries.py
+++ b/tests/unit_tests/libs/controllers/test_predictor_timeseries.py
@@ -73,6 +73,9 @@ class TestPredictorTimeseries:
 
         results = mdb.predict(when_data=test_file_name, use_gpu=False)
 
+        # Results should only be given for the rows with full history
+        print(results)
+        assert len(results) == len(columns_test[-1]) - 2
         for row in results:
             expect_columns = [label_headers[0],
                               label_headers[0] + '_confidence']
@@ -125,6 +128,9 @@ class TestPredictorTimeseries:
         )
 
         results = mdb.predict(when_data=test_file_name, use_gpu=False)
+
+        # Results should only be given for the rows with full history
+        assert len(results) == len(columns_test[-1]) - 2
 
         for row in results:
             assert label_headers[0] + '_confidence' in row

--- a/tests/unit_tests/utils.py
+++ b/tests/unit_tests/utils.py
@@ -135,7 +135,6 @@ def generate_timeseries_labels(columns):
 
     return labels
 
-
 def columns_to_file(columns, filename, headers=None):
     separator = ','
     with open(filename, 'w', encoding='utf-8') as fp:


### PR DESCRIPTION
* Database history for timeseries problems is only used when a flag in the advanced args is specified
* Removed the `dynamic_window` argument since it's not implemented and doing so is harder than I thought.
* Removed the `use_order_col` argument since the interface is already very complex and I wanted to simplify it. We can always add it later fairly easily if needed
* Completely refactored how we reshape timeseries data to use pandas function, this should => significant speedups

## Important

There was a bug where if a `group_by` was specified or if the rows provided during `predict` were not already ordered, mindsdb would return predictions in an arbitrary order, instead of that in which the rows were given during `predict`. This basically made predicting with a group by or with unordered data return garbage. 

I added tests to catch this and the refactor of the timeseries reshape was in large part motivated by fixing this.

*Note: interface changes are described in this docs PR: https://github.com/mindsdb/mindsdb-docs/pull/115*