### PR TITLE
Handle nr_predictions > 1 in .explain()

### DIFF
--- a/mindsdb_native/libs/data_types/transaction_output_row.py
+++ b/mindsdb_native/libs/data_types/transaction_output_row.py
@@ -38,7 +38,12 @@ class TransactionOutputRow:
             answers[pred_col] = {}
             prediction_row = {col: self._data[col][self._row_index] for col in self._data.keys()}
 
-            answers[pred_col]['predicted_value'] = prediction_row[pred_col]
+            if self._transaction_output._transaction.lmd['tss']['is_timeseries'] and \
+                    self._transaction_output._transaction.lmd['tss']['nr_predictions'] > 1:
+                answers[pred_col]['predicted_value'] = prediction_row[pred_col][0]
+                answers[pred_col]['all_predicted_values'] = prediction_row[pred_col]
+            else:
+                answers[pred_col]['predicted_value'] = prediction_row[pred_col]
 
 
             if f'{pred_col}_model_confidence' in prediction_row:

--- a/mindsdb_native/libs/helpers/general_helpers.py
+++ b/mindsdb_native/libs/helpers/general_helpers.py
@@ -182,12 +182,13 @@ def evaluate_generic_accuracy(column, predictions, true_values, **kwargs):
 def evaluate_array_accuracy(column, predictions, true_values, **kwargs):
     accuracy = 0
     true_values = list(true_values)
+    acc_f = balanced_accuracy_score if kwargs['categorical'] else r2_score
     for i in range(len(predictions[column])):
         if isinstance(true_values[i],list):
-            accuracy += r2_score(predictions[column][i],true_values[i])
+            accuracy += acc_f(predictions[column][i],true_values[i])
         else:
             # For the T+1 usecase
-            accuracy = r2_score([x[0] for x in predictions[column]], true_values)
+            accuracy = acc_f([x[0] for x in predictions[column]], true_values)
             return accuracy
 
     accuracy = accuracy/len(predictions[column])
@@ -208,6 +209,8 @@ def evaluate_accuracy(predictions, data_frame, col_stats, output_columns, backen
                 evaluator = evaluate_classification_accuracy
         elif col_type == DATA_TYPES.SEQUENTIAL:
             evaluator = evaluate_array_accuracy
+            kwargs['categorical'] = True if DATA_TYPES.CATEGORICAL in \
+                                            col_stats[column]['typing']['data_type_dist'] else False
         else:
             evaluator = evaluate_generic_accuracy
         column_score = evaluator(

--- a/mindsdb_native/libs/helpers/general_helpers.py
+++ b/mindsdb_native/libs/helpers/general_helpers.py
@@ -210,7 +210,7 @@ def evaluate_accuracy(predictions, data_frame, col_stats, output_columns, backen
         elif col_type == DATA_TYPES.SEQUENTIAL:
             evaluator = evaluate_array_accuracy
             kwargs['categorical'] = True if DATA_TYPES.CATEGORICAL in \
-                                            col_stats[column]['typing']['data_type_dist'] else False
+                                            col_stats[column]['typing'].get('data_type_dist', []) else False
         else:
             evaluator = evaluate_generic_accuracy
         column_score = evaluator(

--- a/mindsdb_native/libs/phases/data_splitter/data_splitter.py
+++ b/mindsdb_native/libs/phases/data_splitter/data_splitter.py
@@ -88,7 +88,7 @@ class DataSplitter(BaseModule):
                 self.transaction.input_data.test_df['make_predictions'] = [True] * len(self.transaction.input_data.test_df)
                 self.transaction.input_data.test_df = pd.concat([self.transaction.input_data.test_df,historical_train])
 
-                self.transaction.input_data.validation_df['make_predictions'] = [True] * (len(self.transaction.input_data.validation_df) - n_preds_cutoff) + [False] * n_preds_cutoff
+                self.transaction.input_data.validation_df['make_predictions'] = [True] * len(self.transaction.input_data.validation_df)
                 self.transaction.input_data.validation_df = pd.concat([self.transaction.input_data.validation_df,historical_test,deepcopy(historical_train)])
 
             self.transaction.input_data.data_frame = None

--- a/mindsdb_native/libs/phases/data_splitter/data_splitter.py
+++ b/mindsdb_native/libs/phases/data_splitter/data_splitter.py
@@ -83,11 +83,14 @@ class DataSplitter(BaseModule):
                 historical_test = deepcopy(self.transaction.input_data.test_df)
                 historical_test['make_predictions'] = [False] * len(historical_test)
 
-                n_preds = self.transaction.lmd['tss']['nr_predictions']
-                self.transaction.input_data.test_df['make_predictions'] = [True] * (len(self.transaction.input_data.test_df) - n_preds) + [False] * n_preds
+                if self.transaction.lmd['tss'].get('nr_predictions', None):
+                    n_preds_cutoff = self.transaction.lmd['tss']['nr_predictions'] - 1
+                else:
+                    n_preds_cutoff = 0
+                self.transaction.input_data.test_df['make_predictions'] = [True] * (len(self.transaction.input_data.test_df) - n_preds_cutoff) + [False] * n_preds_cutoff
                 self.transaction.input_data.test_df = pd.concat([self.transaction.input_data.test_df,historical_train])
 
-                self.transaction.input_data.validation_df['make_predictions'] = [True] * (len(self.transaction.input_data.validation_df) - n_preds) + [False] * n_preds
+                self.transaction.input_data.validation_df['make_predictions'] = [True] * (len(self.transaction.input_data.validation_df) - n_preds_cutoff) + [False] * n_preds_cutoff
                 self.transaction.input_data.validation_df = pd.concat([self.transaction.input_data.validation_df,historical_test,deepcopy(historical_train)])
 
             self.transaction.input_data.data_frame = None

--- a/mindsdb_native/libs/phases/data_splitter/data_splitter.py
+++ b/mindsdb_native/libs/phases/data_splitter/data_splitter.py
@@ -83,10 +83,11 @@ class DataSplitter(BaseModule):
                 historical_test = deepcopy(self.transaction.input_data.test_df)
                 historical_test['make_predictions'] = [False] * len(historical_test)
 
-                self.transaction.input_data.test_df['make_predictions'] = [True] * len(self.transaction.input_data.test_df)
+                n_preds = self.transaction.lmd['tss']['nr_predictions']
+                self.transaction.input_data.test_df['make_predictions'] = [True] * (len(self.transaction.input_data.test_df) - n_preds) + [False] * n_preds
                 self.transaction.input_data.test_df = pd.concat([self.transaction.input_data.test_df,historical_train])
 
-                self.transaction.input_data.validation_df['make_predictions'] = [True] * len(self.transaction.input_data.validation_df)
+                self.transaction.input_data.validation_df['make_predictions'] = [True] * (len(self.transaction.input_data.validation_df) - n_preds) + [False] * n_preds
                 self.transaction.input_data.validation_df = pd.concat([self.transaction.input_data.validation_df,historical_test,deepcopy(historical_train)])
 
             self.transaction.input_data.data_frame = None


### PR DESCRIPTION
See #238. For time series tasks with `nr_predictions` > 1, we store the complete array of predictions in `all_predicted_values`.