### PR TITLE
Adding google cloud storage datasource

### DIFF
--- a/mindsdb_native/libs/data_sources/gcs_ds.py
+++ b/mindsdb_native/libs/data_sources/gcs_ds.py
@@ -1,0 +1,39 @@
+import os 
+
+from google.cloud import storage
+
+from mindsdb_native.libs.data_types.data_source import DataSource
+from mindsdb_native.libs.data_sources.file_ds import FileDS
+from mindsdb_native import F
+
+
+class GCSDS(DataSource):
+
+    def _setup(self, bucket_name, file_path, path_to_auth_json):
+
+        self._bucket_name = bucket_name
+        self._file_name = os.path.basename(file_path)
+
+        gc_client = storage.Client.from_service_account_json(json_credentials_path=path_to_auth_json)
+        bucket = gc_client.get_bucket(bucket_name)
+
+        blob = storage.Blob(file_path, bucket)
+
+        self.tmp_file_name = '.tmp_mindsdb_data_file'
+
+        with open(self.tmp_file_name, 'wb') as fw:
+            gc_client.download_blob_to_file(blob, fw)
+
+        file_ds = FileDS(self.tmp_file_name)
+        return file_ds._df, file_ds._col_map
+
+    def _cleanup(self):
+        os.remove(self.tmp_file_name)
+
+
+    def name(self):
+        return '{}: {}/{}'.format(
+            self.__class__.__name__,
+            self._bucket_name,
+            self._file_name
+        )

--- a/optional_requirements_extra_data_sources.txt
+++ b/optional_requirements_extra_data_sources.txt
@@ -2,24 +2,5 @@ boto3 >= 1.9.0
 pg8000 >= 1.15.3
 python-tds >= 1.10.0
 pymongo >= 3.10.1
-cachetools==4.1.1
-certifi==2020.6.20
-cffi==1.14.3
-chardet==3.0.4
-google-api-core==1.23.0
-google-auth==1.22.1
-google-cloud-core==1.4.3
-google-cloud-storage==1.32.0
-google-crc32c==1.0.0
-google-resumable-media==1.1.0
-googleapis-common-protos==1.52.0
-idna==2.10
-protobuf==3.13.0
-pyasn1==0.4.8
-pyasn1-modules==0.2.8
-pycparser==2.20
-pytz==2020.1
-requests==2.24.0
-rsa==4.6
-six==1.15.0
-urllib3==1.25.11
+google-cloud-storage
+google-auth

--- a/optional_requirements_extra_data_sources.txt
+++ b/optional_requirements_extra_data_sources.txt
@@ -2,3 +2,24 @@ boto3 >= 1.9.0
 pg8000 >= 1.15.3
 python-tds >= 1.10.0
 pymongo >= 3.10.1
+cachetools==4.1.1
+certifi==2020.6.20
+cffi==1.14.3
+chardet==3.0.4
+google-api-core==1.23.0
+google-auth==1.22.1
+google-cloud-core==1.4.3
+google-cloud-storage==1.32.0
+google-crc32c==1.0.0
+google-resumable-media==1.1.0
+googleapis-common-protos==1.52.0
+idna==2.10
+protobuf==3.13.0
+pyasn1==0.4.8
+pyasn1-modules==0.2.8
+pycparser==2.20
+pytz==2020.1
+requests==2.24.0
+rsa==4.6
+six==1.15.0
+urllib3==1.25.11


### PR DESCRIPTION
Fix for mindsdb [#797](https://github.com/mindsdb/mindsdb/issues/797) 
Please let me know if this looks correct and if something should be changed about how to take credentials to access gcs bucket and file. 

I also added the extra requirements for gcs in the optional_requirements_extra_data_sources.txt . 
For testing, we will need a .json credentials file for a service account from GCS and a bucket+file on GCS that allows access for the credentials provided. 
Please let me know if anything is wrong and how I can change it. Thanks!