### PR TITLE
Return models list, if predictor is not fully initialised

### DIFF
--- a/mindsdb_native/libs/controllers/functional.py
+++ b/mindsdb_native/libs/controllers/functional.py
@@ -483,7 +483,13 @@ def get_model_data(model_name=None, lmd=None):
 
 def get_models():
     models = []
-    for p in [x for x in Path(CONFIG.MINDSDB_STORAGE_PATH).iterdir() if x.is_dir()]:
+    predictors = [
+        x for x in Path(CONFIG.MINDSDB_STORAGE_PATH).iterdir() if
+            x.is_dir()
+            and x.joinpath('light_model_metadata.pickle').is_file()
+            and x.joinpath('heavy_model_metadata.pickle').is_file()
+    ]
+    for p in predictors:
         model_name = p.name
         try:
             amd = get_model_data(model_name)


### PR DESCRIPTION
Fix for: If predictor is not fully initialised (just added, `light_model_metadata.pickle` и `heavy_model_metadata.pickle` not exists yet), then `get_models()` was return error.