### PR TITLE
fix conformal test

### DIFF
--- a/tests/unit_tests/libs/helpers/test_conformal.py
+++ b/tests/unit_tests/libs/helpers/test_conformal.py
@@ -65,7 +65,12 @@ class TestConformal(unittest.TestCase):
             te[target] = te[target].astype(label_type)
 
             p = Predictor(f"ConformalTest_{type_name}")
-            p.learn(from_data=tr, to_predict=target, stop_training_in_x_seconds=1)
+            p.learn(
+                from_data=tr,
+                to_predict=target,
+                stop_training_in_x_seconds=1,
+                advanced_args={'debug': True}
+            )
 
             r = p.predict(when_data=te)
             r = [x.explanation[target] for x in r]

--- a/tests/unit_tests/libs/helpers/test_conformal.py
+++ b/tests/unit_tests/libs/helpers/test_conformal.py
@@ -31,7 +31,12 @@ class TestConformal(unittest.TestCase):
 
         x_tr = self._df_from_xy(X_train, Y_train, target)
         p = Predictor("ConformalTest")
-        p.learn(from_data=x_tr, to_predict=target, stop_training_in_x_seconds=1)
+        p.learn(
+            from_data=x_tr,
+            to_predict=target,
+            stop_training_in_x_seconds=1,
+            advanced_args={'debug': True}
+        )
 
         x_te = self._df_from_xy(X_test, Y_test, target)
         r = p.predict(when_data=x_te)


### PR DESCRIPTION
This run https://github.com/mindsdb/mindsdb_native/pull/284/checks?check_run_id=1363478827
has one test that failing because all mixers had low accuracy.
Now `advanced_args['debug']` is set to `True` and the exception will not be raised