### PR TITLE
Rename "previous_" columns 

### DIFF
--- a/mindsdb_native/libs/helpers/conformal_helpers.py
+++ b/mindsdb_native/libs/helpers/conformal_helpers.py
@@ -49,7 +49,7 @@ class ConformalRegressorAdapter(RegressorAdapter):
         self.ignore_columns = fit_params['columns_to_ignore']
         self.ar = fit_params['use_previous_target']
         if self.ar:
-            self.columns.append(f'previous_{self.target}')
+            self.columns.append(f'__mdb_ts_previous_{self.target}')
 
     def fit(self, x, y):
         """
@@ -84,7 +84,7 @@ class ConformalClassifierAdapter(ClassifierAdapter):
         self.ignore_columns = fit_params['columns_to_ignore']
         self.ar = fit_params['use_previous_target']
         if self.ar:
-            self.columns.append(f'previous_{self.target}')
+            self.columns.append(f'__mdb_ts_previous_{self.target}')
 
     def fit(self, x, y):
         """

--- a/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
+++ b/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
@@ -120,7 +120,7 @@ class LightwoodBackend:
                             arr = [None] + arr
                         previous_target_values_arr.append(arr)
 
-                    df_arr[k][f'previous_{target_column}'] = previous_target_values_arr
+                    df_arr[k][f'__mdb_ts_previous_{target_column}'] = previous_target_values_arr
                     for timestep_index in range(1, self.nr_predictions):
                         next_target_value_arr = list(df_arr[k][target_column])
                         for del_index in range(0,timestep_index):
@@ -227,7 +227,7 @@ class LightwoodBackend:
 
                 if self.transaction.lmd['tss']['use_previous_target']:
                     p_col_config = copy.deepcopy(col_config)
-                    p_col_config['name'] = f"previous_{p_col_config['name']}"
+                    p_col_config['name'] = f"__mdb_ts_previous_{p_col_config['name']}"
                     p_col_config['original_type'] = col_config['type']
                     p_col_config['type'] = ColumnDataTypes.TIME_SERIES
 


### PR DESCRIPTION
Addresses [this issue](https://github.com/mindsdb/lightwood/issues/306).

- Renames `previous_` columns to `__mdb_ts_previous_`, to avoid potential collisions with dataset's own columns.

NOTE: This [PR](https://github.com/mindsdb/lightwood/pull/313) needs to be merged into staging for tests to pass.