### PR TITLE
Scipy dependency fix to work with 3.9

### DIFF
--- a/.github/workflows/mindsdb_native.yml
+++ b/.github/workflows/mindsdb_native.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.6,3.7,3.8]
+        python-version: [3.6,3.7,3.8,3.9]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ numpy >= 1.15.2
 pandas >= 0.23.4
 pytz >= 2018.5
 requests >= 2.20.0
-scipy >= 1.1.0, <= 1.4.1
+scipy >= 1.1.0
 scikit-learn >=  0.22.1
 colorlog >= 4.0.2
 xlrd >= 1.0.0


### PR DESCRIPTION
Also closes #300 | closes #309  (hopefully)