### PR TITLE
Remove ProbabilisticValidator

### DIFF
--- a/mindsdb_native/libs/data_types/transaction_output_row.py
+++ b/mindsdb_native/libs/data_types/transaction_output_row.py
@@ -44,18 +44,20 @@ class TransactionOutputRow:
                 answers[pred_col]['all_predicted_values'] = prediction_row[pred_col]
             else:
                 answers[pred_col]['predicted_value'] = prediction_row[pred_col]
-    
-            answers[pred_col]['confidence'] = round(prediction_row[f'{pred_col}_confidence'], 4)
 
-            quality = 'very confident'
-            if answers[pred_col]['confidence'] < 0.8:
-                quality = 'confident'
-            if answers[pred_col]['confidence'] < 0.6:
-                quality = 'somewhat confident'
-            if answers[pred_col]['confidence'] < 0.4:
-                quality = 'not very confident'
-            if answers[pred_col]['confidence'] < 0.2:
-                quality = 'not confident'
+            if prediction_row[f'{pred_col}_confidence'] is not None:
+                answers[pred_col]['confidence'] = round(prediction_row[f'{pred_col}_confidence'], 4)
+                quality = 'very confident'
+                if answers[pred_col]['confidence'] < 0.8:
+                    quality = 'confident'
+                if answers[pred_col]['confidence'] < 0.6:
+                    quality = 'somewhat confident'
+                if answers[pred_col]['confidence'] < 0.4:
+                    quality = 'not very confident'
+                if answers[pred_col]['confidence'] < 0.2:
+                    quality = 'not confident'
+            else:
+                quality = 'missing confidence estimation'
 
             answers[pred_col]['prediction_quality'] = quality
 

--- a/mindsdb_native/libs/data_types/transaction_output_row.py
+++ b/mindsdb_native/libs/data_types/transaction_output_row.py
@@ -44,14 +44,8 @@ class TransactionOutputRow:
                 answers[pred_col]['all_predicted_values'] = prediction_row[pred_col]
             else:
                 answers[pred_col]['predicted_value'] = prediction_row[pred_col]
-
-
-            if f'{pred_col}_model_confidence' in prediction_row:
-                answers[pred_col]['confidence'] = (prediction_row[f'{pred_col}_model_confidence'] * 3 + prediction_row[f'{pred_col}_confidence'] * 1)/4
-            else:
-                answers[pred_col]['confidence'] = prediction_row[f'{pred_col}_confidence']
-
-            answers[pred_col]['confidence'] = round(answers[pred_col]['confidence'], 4)
+    
+            answers[pred_col]['confidence'] = round(prediction_row[f'{pred_col}_confidence'], 4)
 
             quality = 'very confident'
             if answers[pred_col]['confidence'] < 0.8:

--- a/mindsdb_native/libs/helpers/accuracy_stats.py
+++ b/mindsdb_native/libs/helpers/accuracy_stats.py
@@ -1,21 +1,14 @@
 from mindsdb_native.libs.constants.mindsdb import *
 from mindsdb_native.libs.helpers.general_helpers import get_value_bucket
 
-from sklearn.naive_bayes import BernoulliNB
 from sklearn.metrics import confusion_matrix
-import numpy as np
 import random
 
 
-class ProbabilisticValidator:
+class AccStats:
     """
-    # The probabilistic validator is a quick to train model used for validating the predictions of our main model
-    # It is fit to the results our model gets on the validation set
+    Computes accuracy stats and a confusion matrix for the validation dataset
     """
-    _probabilistic_model = None
-    _X_buff = None
-    _Y_buff = None
-
 
     def __init__(self, col_stats, col_name, input_columns):
         """
@@ -29,17 +22,11 @@ class ProbabilisticValidator:
         if 'percentage_buckets' in col_stats:
             self.buckets = col_stats['percentage_buckets']
 
-        self._probabilistic_model = BernoulliNB()
-
     def fit(self, real_df, predictions_arr, missing_col_arr, hmd=None):
         """
-        # Fit the probabilistic validator
-
         :param real_df: A dataframe with the real inputs and outputs for every row
         :param predictions_arr: An array containing arrays of predictions, one containing the "normal" predictions and the rest containing predictions with various missing column
         :param missing_col_arr: The missing columns for each of the prediction arrays, same order as the arrays in `predictions_arr`, starting from the second element of `predictions_arr` (The first is assumed to have no missing columns)
-
-
         """
         self.real_values_bucketized = []
         self.normal_predictions_bucketized = []
@@ -56,9 +43,6 @@ class ProbabilisticValidator:
                 if str(row[col]) in ('None', 'nan', '', 'Nan', 'NAN', 'NaN'):
                     present_inputs[i] = 0
             real_present_inputs_arr.append(present_inputs)
-
-        X = []
-        Y = []
 
         for n in range(len(predictions_arr)):
             for m in range(len(predictions_arr[n][self.col_name])):
@@ -80,21 +64,13 @@ class ProbabilisticValidator:
                 if self.buckets is not None:
                     predicted_value_b = get_value_bucket(predicted_value, self.buckets, self.col_stats, hmd)
                     real_value_b = get_value_bucket(real_value, self.buckets, self.col_stats, hmd)
-                    X.append([0] * (len(self.buckets) + 1))
-                    X[-1][predicted_value_b] = 1
                 else:
                     predicted_value_b = predicted_value
                     real_value_b = real_value
 
-                    X.append([])
-
                 has_confidence_range = self.col_stats['typing']['data_type'] == DATA_TYPES.NUMERIC and f'{self.col_name}_confidence_range' in predictions_arr[n]
 
-                if has_confidence_range:
-                    predicted_range = predictions_arr[n][f'{self.col_name}_confidence_range'][m]
-                    Y.append(predicted_range[0] < real_value < predicted_range[1])
-                else:
-                    Y.append(real_value_b == predicted_value_b)
+                predicted_range = predictions_arr[n][f'{self.col_name}_confidence_range'][m] if has_confidence_range else (None, None)
 
                 if n == 0:
                     self.real_values_bucketized.append(real_value_b)
@@ -106,42 +82,6 @@ class ProbabilisticValidator:
                 if n > 0:
                     for missing_col in missing_col_arr[n - 1]:
                         feature_existance[self.input_columns.index(missing_col)] = 0
-
-                X[-1] += feature_existance
-
-        log_types = np.seterr()
-        np.seterr(divide='ignore')
-        self._probabilistic_model.fit(X, Y)
-        np.seterr(divide=log_types['divide'])
-
-    def evaluate_prediction_accuracy(self, features_existence, predicted_value):
-        """
-        # Fit the probabilistic validator on an observation
-        :param features_existence: A vector of 0 and 1 representing the existence of all the features (0 == not exists, 1 == exists)
-        :param predicted_value: The predicted value/label
-        :return: The probability (from 0 to 1) of our prediction being accurate (within the same histogram bucket as the real value)
-        """
-        if self.buckets is not None:
-            predicted_value_b = get_value_bucket(predicted_value, self.buckets, self.col_stats)
-            X = [0] * (len(self.buckets) + 1)
-            X[predicted_value_b] = 1
-            X = [X + features_existence]
-        else:
-            X = [features_existence]
-
-        try:
-            true_index = self._probabilistic_model.classes_.tolist().index(True)
-        except:
-            print('Only got classes: ', str(self._probabilistic_model.classes_.tolist()), ' in the probabilistic model\'s Y vector !')
-            true_index = None
-
-        if true_index is None:
-            probability_true_prediction = 0
-        else:
-            probability_true_prediction = self._probabilistic_model.predict_proba(np.array(X))[0][true_index]
-
-        return probability_true_prediction
-
 
     def get_accuracy_stats(self):
 
@@ -202,4 +142,5 @@ class ProbabilisticValidator:
                 ,'x': [x[1] for x in sampled_numerical_samples_arr]
             }
 
+        print(overall_accuracy, accuracy_histogram, cm, accuracy_samples)
         return overall_accuracy, accuracy_histogram, cm, accuracy_samples

--- a/mindsdb_native/libs/helpers/accuracy_stats.py
+++ b/mindsdb_native/libs/helpers/accuracy_stats.py
@@ -142,5 +142,4 @@ class AccStats:
                 ,'x': [x[1] for x in sampled_numerical_samples_arr]
             }
 
-        print(overall_accuracy, accuracy_histogram, cm, accuracy_samples)
         return overall_accuracy, accuracy_histogram, cm, accuracy_samples

--- a/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
+++ b/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
@@ -3,7 +3,7 @@ from mindsdb_native.libs.constants.mindsdb import *
 from mindsdb_native.libs.phases.base_module import BaseModule
 from mindsdb_native.libs.helpers.general_helpers import evaluate_accuracy
 from mindsdb_native.libs.helpers.conformal_helpers import ConformalClassifierAdapter, ConformalRegressorAdapter, clean_df
-from mindsdb_native.libs.helpers.probabilistic_validator import ProbabilisticValidator
+from mindsdb_native.libs.helpers.accuracy_stats import AccStats
 from mindsdb_native.libs.data_types.mindsdb_logger import log
 from sklearn.metrics import balanced_accuracy_score, r2_score
 
@@ -20,7 +20,7 @@ class ModelAnalyzer(BaseModule):
     def run(self):
         np.seterr(divide='warn', invalid='warn')
         """
-        # Runs the model on the validation set in order to fit a probabilistic model that will evaluate the accuracy of future predictions
+        # Runs the model on the validation set in order to evaluate the accuracy and confidence of future predictions
         """
 
         validation_df = self.transaction.input_data.validation_df
@@ -105,13 +105,12 @@ class ModelAnalyzer(BaseModule):
             # normalize from 0 to 10
             self.transaction.lmd['column_importances'][col] = 10 * max(0, accuracy_increase)
 
-        # Run Probabilistic Validator
+        # Get accuracy stats
         overall_accuracy_arr = []
         self.transaction.lmd['accuracy_histogram'] = {}
         self.transaction.lmd['confusion_matrices'] = {}
         self.transaction.lmd['accuracy_samples'] = {}
-        self.transaction.hmd['probabilistic_validators'] = {}
-
+        self.transaction.hmd['acc_stats'] = {}
 
         self.transaction.lmd['train_data_accuracy'] = {}
         self.transaction.lmd['test_data_accuracy'] = {}
@@ -159,17 +158,17 @@ class ModelAnalyzer(BaseModule):
             )
 
         for col in output_columns:
-            pval = ProbabilisticValidator(col_stats=self.transaction.lmd['stats_v2'][col], col_name=col, input_columns=input_columns)
+            acc_stats = AccStats(col_stats=self.transaction.lmd['stats_v2'][col], col_name=col, input_columns=input_columns)
             predictions_arr = [normal_predictions_test] + [x for x in empty_input_predictions_test.values()]
 
-            pval.fit(test_df, predictions_arr, [[ignored_column] for ignored_column in empty_input_predictions_test])
-            overall_accuracy, accuracy_histogram, cm, accuracy_samples = pval.get_accuracy_stats()
+            acc_stats.fit(test_df, predictions_arr, [[ignored_column] for ignored_column in empty_input_predictions_test])
+            overall_accuracy, accuracy_histogram, cm, accuracy_samples = acc_stats.get_accuracy_stats()
             overall_accuracy_arr.append(overall_accuracy)
 
             self.transaction.lmd['accuracy_histogram'][col] = accuracy_histogram
             self.transaction.lmd['confusion_matrices'][col] = cm
             self.transaction.lmd['accuracy_samples'][col] = accuracy_samples
-            self.transaction.hmd['probabilistic_validators'][col] = pickle_obj(pval)
+            self.transaction.hmd['acc_stats'][col] = pickle_obj(acc_stats)
 
         self.transaction.lmd['validation_set_accuracy'] = sum(overall_accuracy_arr)/len(overall_accuracy_arr)
 


### PR DESCRIPTION
Related: #259 

- Removes ProbabilisticValidator, confidence is now entirely estimated with conformal predictors. 
- Tasks with categorical tags unsupported as of now. 
- Repackaged remaining accuracy methods into AccStats class.
- Pending: use nonconformist confidence ranges instead of Lightwood's for accuracy stats. This should also solve #298.