### PR TITLE
Fix wrong representation of None for string type

### DIFF
--- a/mindsdb_native/libs/phases/data_transformer/data_transformer.py
+++ b/mindsdb_native/libs/phases/data_transformer/data_transformer.py
@@ -125,10 +125,10 @@ class DataTransformer(BaseModule):
                 if data_subtype == DATA_SUBTYPES.TAGS:
                     self._apply_to_all_data(input_data, column, _tags_to_tuples, transaction_type)
                 else:
-                    self._apply_to_all_data(input_data, column, str, transaction_type)
+                    self._apply_to_all_data(input_data, column, lambda x: x if x is None else str(x), transaction_type)
 
             if data_type == DATA_TYPES.TEXT:
-                self._apply_to_all_data(input_data, column, str, transaction_type)
+                self._apply_to_all_data(input_data, column, lambda x: x if x is None else str(x), transaction_type)
 
             if data_type == DATA_TYPES.SEQUENTIAL:
                 if data_subtype == DATA_SUBTYPES.ARRAY:


### PR DESCRIPTION
Closed #66 

before:
```
{'number_of_rooms': ['2'], 'number_of_bathrooms': ['1'], 'sqft': [1190], 'location': ['None'], 'days_on_market': [None], 'initial_price': [2000], 'neighborhood': ['None'], 'rental_price': [3090], '__observed_rental_price': [None], 'rental_price_model_confidence': [0.99], 'rental_price_confidence_range': [[2972.0, 3208.0]], 'rental_price_confidence': [0.99], 'model_rental_price': [3090]}
```
after:
```
{'number_of_rooms': ['2'], 'number_of_bathrooms': ['1'], 'sqft': [1190], 'location': [None], 'days_on_market': [None], 'initial_price': [2000], 'neighborhood': [None], 'rental_price': [3004], '__observed_rental_price': [None], 'rental_price_model_confidence': [0.99], 'rental_price_confidence_range': [[2886.0, 3122.0]], 'rental_price_confidence': [0.99], 'model_rental_price': [3004]}
```