### PR TITLE
Skip model analyzer if too many columns

### DIFF
--- a/mindsdb_native/libs/controllers/predictor.py
+++ b/mindsdb_native/libs/controllers/predictor.py
@@ -262,8 +262,7 @@ class Predictor:
                 debug = advanced_args.get('debug', False),
                 allow_incomplete_history = advanced_args.get('allow_incomplete_history', False),
                 quick_learn = advanced_args.get('quick_learn', False),
-                quick_predict = advanced_args.get('quick_predict', False),
-                force_model_analysis = advanced_args.get('force_model_analysis', False)
+                quick_predict = advanced_args.get('quick_predict', False)
             )
 
             if rebuild_model is False:

--- a/mindsdb_native/libs/controllers/predictor.py
+++ b/mindsdb_native/libs/controllers/predictor.py
@@ -339,10 +339,10 @@ class Predictor:
             return accuracy_dict
 
     def quick_predict(self,
-                when_data,
-                use_gpu=None,
-                advanced_args=None,
-                backend=None):
+                      when_data,
+                      use_gpu=None,
+                      advanced_args=None,
+                      backend=None):
 
         if advanced_args is None:
             advanced_args = {}

--- a/mindsdb_native/libs/controllers/predictor.py
+++ b/mindsdb_native/libs/controllers/predictor.py
@@ -261,7 +261,7 @@ class Predictor:
                 setup_args = from_data.setup_args if hasattr(from_data, 'setup_args') else None,
                 debug = advanced_args.get('debug', False),
                 allow_incomplete_history = advanced_args.get('allow_incomplete_history', False),
-                quick_learn = advanced_args.get('quick_learn', False),
+                quick_learn = advanced_args.get('quick_learn', None),
                 quick_predict = advanced_args.get('quick_predict', False),
                 apply_to_columns = advanced_args.get('apply_to_columns', {})
             )

--- a/mindsdb_native/libs/controllers/predictor.py
+++ b/mindsdb_native/libs/controllers/predictor.py
@@ -357,6 +357,7 @@ class Predictor:
         if advanced_args is None:
             advanced_args = {}
         advanced_args['quick_predict'] = True
+        advanced_args['return_raw_predictions'] = True
 
         return self.predict(when_data, use_gpu, advanced_args, backend)
 
@@ -411,7 +412,8 @@ class Predictor:
                 force_disable_cache = advanced_args.get('force_disable_cache', disable_lightwood_transform_cache),
                 use_database_history = advanced_args.get('use_database_history', False),
                 allow_incomplete_history = advanced_args.get('allow_incomplete_history', False),
-                quick_predict = advanced_args.get('quick_predict', False)
+                quick_predict = advanced_args.get('quick_predict', False),
+                return_raw_predictions = advanced_args.get('return_raw_predictions', False)
             )
 
             self.transaction = PredictTransaction(

--- a/mindsdb_native/libs/controllers/predictor.py
+++ b/mindsdb_native/libs/controllers/predictor.py
@@ -339,8 +339,6 @@ class Predictor:
 
             return accuracy_dict
 
-<<<<<<< HEAD
-=======
     def _attach_datasource(self, setup_args, ds_class, lmd, hmd):
         lmd['setup_args'] = setup_args
         if ds_class is not None:
@@ -362,7 +360,6 @@ class Predictor:
 
         return self.predict(when_data, use_gpu, advanced_args, backend)
 
->>>>>>> 47a1f58482d3193603007ab0904948dc13d35cc2
     def predict(self,
                 when_data,
                 use_gpu=None,

--- a/mindsdb_native/libs/controllers/predictor.py
+++ b/mindsdb_native/libs/controllers/predictor.py
@@ -338,18 +338,6 @@ class Predictor:
 
             return accuracy_dict
 
-    def quick_predict(self,
-                      when_data,
-                      use_gpu=None,
-                      advanced_args=None,
-                      backend=None):
-
-        if advanced_args is None:
-            advanced_args = {}
-        advanced_args['quick_predict'] = True
-
-        return self.predict(when_data, use_gpu, advanced_args, backend)
-
     def predict(self,
                 when_data,
                 use_gpu=None,

--- a/mindsdb_native/libs/controllers/predictor.py
+++ b/mindsdb_native/libs/controllers/predictor.py
@@ -261,7 +261,8 @@ class Predictor:
                 debug = advanced_args.get('debug', False),
                 allow_incomplete_history = advanced_args.get('allow_incomplete_history', False),
                 quick_learn = advanced_args.get('quick_learn', False),
-                quick_predict = advanced_args.get('quick_predict', False)
+                quick_predict = advanced_args.get('quick_predict', False),
+                force_model_analysis = advanced_args.get('force_model_analysis', False)
             )
 
             if rebuild_model is False:

--- a/mindsdb_native/libs/controllers/transaction.py
+++ b/mindsdb_native/libs/controllers/transaction.py
@@ -234,7 +234,7 @@ class LearnTransaction(Transaction):
             # quick_learn can be set to False explicitly
             if self.lmd['quick_learn'] is None:
                 n_cols = len(self.input_data.columns)
-                n_cells = n_cols * len(self.input_data._sample_df)
+                n_cells = n_cols * len(self.input_data._sample_df or self.input_data.data_frame)
                 if n_cols >= 80 and n_cells > int(1e5):
                     self.log.warning('Data has too many columns, setting quick_learn to True')
                     self.lmd['quick_learn'] = True

--- a/mindsdb_native/libs/controllers/transaction.py
+++ b/mindsdb_native/libs/controllers/transaction.py
@@ -234,7 +234,7 @@ class LearnTransaction(Transaction):
             # quick_learn can be set to False explicitly
             if self.lmd['quick_learn'] is None:
                 n_cols = len(self.input_data.columns)
-                n_cells = n_cols * len(self.input_data.sample_df())
+                n_cells = n_cols * len(self.input_data._sample_df)
                 if n_cols >= 80 and n_cells > int(1e5):
                     self.log.warning('Data has too many columns, setting quick_learn to True')
                     self.lmd['quick_learn'] = True

--- a/mindsdb_native/libs/controllers/transaction.py
+++ b/mindsdb_native/libs/controllers/transaction.py
@@ -238,21 +238,19 @@ class LearnTransaction(Transaction):
                 if n_cols >= 80 and n_cells > int(1e5):
                     self.log.warning('Data has too many columns, setting quick_learn to True')
                     self.lmd['quick_learn'] = True
-            
-            if not self.lmd['quick_learn']:
-                predict_method = self.session.predict
 
+            if not self.lmd['quick_learn']:
+                self.lmd['current_phase'] = MODEL_STATUS_ANALYZING
+                self.save_metadata()
+                self._call_phase_module(module_name='ModelAnalyzer')
+            else:
+                predict_method = self.session.predict
                 def predict_method_wrapper(*args, **kwargs):
                     if 'advanced_args' not in kwargs:
                         kwargs['advanced_args'] = {}
                     kwargs['advanced_args']['quick_predict'] = True
                     return predict_method(*args, **kwargs)
-
                 self.session.predict = predict_method_wrapper
-
-                self.lmd['current_phase'] = MODEL_STATUS_ANALYZING
-                self.save_metadata()
-                self._call_phase_module(module_name='ModelAnalyzer')
 
             self.lmd['current_phase'] = MODEL_STATUS_TRAINED
             self.save_metadata()

--- a/mindsdb_native/libs/controllers/transaction.py
+++ b/mindsdb_native/libs/controllers/transaction.py
@@ -238,8 +238,18 @@ class LearnTransaction(Transaction):
                 if n_cols >= 80 and n_cells > int(1e5):
                     self.log.warning('Data has too many columns, setting quick_learn to True')
                     self.lmd['quick_learn'] = True
-
+            
             if not self.lmd['quick_learn']:
+                predict_method = self.session.predict
+
+                def predict_method_wrapper(*args, **kwargs):
+                    if 'advanced_args' not in kwargs:
+                        kwargs['advanced_args'] = {}
+                    kwargs['advanced_args']['quick_predict'] = True
+                    return predict_method(*args, **kwargs)
+
+                self.session.predict = predict_method_wrapper
+
                 self.lmd['current_phase'] = MODEL_STATUS_ANALYZING
                 self.save_metadata()
                 self._call_phase_module(module_name='ModelAnalyzer')

--- a/mindsdb_native/libs/controllers/transaction.py
+++ b/mindsdb_native/libs/controllers/transaction.py
@@ -236,6 +236,7 @@ class LearnTransaction(Transaction):
                 n_cols = len(self.input_data.columns)
                 n_cells = n_cols * len(self.input_data.sample_df())
                 if n_cols >= 80 and n_cells > int(1e5) and not self.lmd['force_model_analysis']:
+                    self.log.warning('Data has too many columns, setting quick_learn to True')
                     self.lmd['quick_learn'] = True
 
             if not self.lmd['quick_learn']:

--- a/mindsdb_native/libs/controllers/transaction.py
+++ b/mindsdb_native/libs/controllers/transaction.py
@@ -220,6 +220,14 @@ class LearnTransaction(Transaction):
                                     input_data=self.input_data)
             self.save_metadata()
 
+            # quick_learn can be set to False explicitly
+            if self.lmd['quick_learn'] is None:
+                n_cols = len(self.input_data.columns)
+                n_cells = n_cols * self.lmd['data_preparation']['used_row_count']
+                if n_cols >= 80 and n_cells > int(1e5):
+                    self.log.warning('Data has too many columns, setting quick_learn to True')
+                    self.lmd['quick_learn'] = True
+
             self._call_phase_module(module_name='DataCleaner')
             self.save_metadata()
 
@@ -230,14 +238,6 @@ class LearnTransaction(Transaction):
             self.lmd['current_phase'] = MODEL_STATUS_TRAINING
             self.save_metadata()
             self._call_phase_module(module_name='ModelInterface', mode='train')
-
-            # quick_learn can be set to False explicitly
-            if self.lmd['quick_learn'] is None:
-                n_cols = len(self.input_data.columns)
-                n_cells = n_cols * len(self.input_data._sample_df or self.input_data.data_frame)
-                if n_cols >= 80 and n_cells > int(1e5):
-                    self.log.warning('Data has too many columns, setting quick_learn to True')
-                    self.lmd['quick_learn'] = True
 
             if self.lmd['quick_learn']:
                 predict_method = self.session.predict

--- a/mindsdb_native/libs/controllers/transaction.py
+++ b/mindsdb_native/libs/controllers/transaction.py
@@ -324,6 +324,9 @@ class PredictTransaction(Transaction):
 
         self._call_phase_module(module_name='ModelInterface', mode='predict')
 
+        if self.transaction.lmd['return_raw_predictions']:
+            return self.transaction.hmd['predictions']
+
         output_data = {col: [] for col in self.lmd['columns']}
 
         if 'make_predictions' in self.input_data.data_frame.columns:

--- a/mindsdb_native/libs/controllers/transaction.py
+++ b/mindsdb_native/libs/controllers/transaction.py
@@ -235,7 +235,7 @@ class LearnTransaction(Transaction):
             if self.lmd['quick_learn'] is None:
                 n_cols = len(self.input_data.columns)
                 n_cells = n_cols * len(self.input_data.sample_df())
-                if n_cols >= 80 and n_cells > int(1e5) and not self.lmd['force_model_analysis']:
+                if n_cols >= 80 and n_cells > int(1e5):
                     self.log.warning('Data has too many columns, setting quick_learn to True')
                     self.lmd['quick_learn'] = True
 

--- a/mindsdb_native/libs/controllers/transaction.py
+++ b/mindsdb_native/libs/controllers/transaction.py
@@ -239,11 +239,7 @@ class LearnTransaction(Transaction):
                     self.log.warning('Data has too many columns, setting quick_learn to True')
                     self.lmd['quick_learn'] = True
 
-            if not self.lmd['quick_learn']:
-                self.lmd['current_phase'] = MODEL_STATUS_ANALYZING
-                self.save_metadata()
-                self._call_phase_module(module_name='ModelAnalyzer')
-            else:
+            if self.lmd['quick_learn']:
                 predict_method = self.session.predict
                 def predict_method_wrapper(*args, **kwargs):
                     if 'advanced_args' not in kwargs:
@@ -251,6 +247,10 @@ class LearnTransaction(Transaction):
                     kwargs['advanced_args']['quick_predict'] = True
                     return predict_method(*args, **kwargs)
                 self.session.predict = predict_method_wrapper
+            else:
+                self.lmd['current_phase'] = MODEL_STATUS_ANALYZING
+                self.save_metadata()
+                self._call_phase_module(module_name='ModelAnalyzer')
 
             self.lmd['current_phase'] = MODEL_STATUS_TRAINED
             self.save_metadata()

--- a/mindsdb_native/libs/controllers/transaction.py
+++ b/mindsdb_native/libs/controllers/transaction.py
@@ -231,13 +231,17 @@ class LearnTransaction(Transaction):
             self.save_metadata()
             self._call_phase_module(module_name='ModelInterface', mode='train')
 
-            MODEL_ANALYZER_COLUMNS_LIMIT = 100
+            # quick_learn can be set to False explicitly
+            if self.lmd['quick_learn'] is None:
+                n_cols = len(self.input_data.columns)
+                n_cells = n_cols * len(self.input_data.sample_df())
+                if n_cols >= 80 and n_cells > int(1e5) and not self.lmd['force_model_analysis']:
+                    self.lmd['quick_learn'] = True
 
             if not self.lmd['quick_learn']:
-                if len(self.input_data.columns) <= MODEL_ANALYZER_COLUMNS_LIMIT or self.lmd['force_model_analysis']:
-                    self.lmd['current_phase'] = MODEL_STATUS_ANALYZING
-                    self.save_metadata()
-                    self._call_phase_module(module_name='ModelAnalyzer')
+                self.lmd['current_phase'] = MODEL_STATUS_ANALYZING
+                self.save_metadata()
+                self._call_phase_module(module_name='ModelAnalyzer')
 
             self.lmd['current_phase'] = MODEL_STATUS_TRAINED
             self.save_metadata()

--- a/mindsdb_native/libs/controllers/transaction.py
+++ b/mindsdb_native/libs/controllers/transaction.py
@@ -223,10 +223,13 @@ class LearnTransaction(Transaction):
             self.save_metadata()
             self._call_phase_module(module_name='ModelInterface', mode='train')
 
+            MODEL_ANALYZER_COLUMNS_LIMIT = 100
+
             if not self.lmd['quick_learn']:
-                self.lmd['current_phase'] = MODEL_STATUS_ANALYZING
-                self.save_metadata()
-                self._call_phase_module(module_name='ModelAnalyzer')
+                if len(self.input_data.columns) <= MODEL_ANALYZER_COLUMNS_LIMIT or self.lmd['force_model_analysis']:
+                    self.lmd['current_phase'] = MODEL_STATUS_ANALYZING
+                    self.save_metadata()
+                    self._call_phase_module(module_name='ModelAnalyzer')
 
             self.lmd['current_phase'] = MODEL_STATUS_TRAINED
             self.save_metadata()

--- a/mindsdb_native/libs/controllers/transaction.py
+++ b/mindsdb_native/libs/controllers/transaction.py
@@ -324,8 +324,8 @@ class PredictTransaction(Transaction):
 
         self._call_phase_module(module_name='ModelInterface', mode='predict')
 
-        if self.transaction.lmd['return_raw_predictions']:
-            return self.transaction.hmd['predictions']
+        if self.lmd['return_raw_predictions']:
+            return self.hmd['predictions']
 
         output_data = {col: [] for col in self.lmd['columns']}
 

--- a/mindsdb_native/libs/helpers/general_helpers.py
+++ b/mindsdb_native/libs/helpers/general_helpers.py
@@ -193,7 +193,6 @@ def evaluate_regression_accuracy(
         column,
         predictions,
         true_values,
-        backend,
         **kwargs
     ):
     return r2_score(true_values, predictions[column])

--- a/mindsdb_native/libs/helpers/general_helpers.py
+++ b/mindsdb_native/libs/helpers/general_helpers.py
@@ -222,15 +222,12 @@ def evaluate_array_accuracy(column, predictions, true_values, **kwargs):
     true_values = list(true_values)
     acc_f = balanced_accuracy_score if kwargs['categorical'] else r2_score
     for i in range(len(predictions[column])):
-        if isinstance(true_values[i],list):
-            acc = max(0, acc_f(predictions[column][i], true_values[i]))
+        if isinstance(true_values[i], list):
+            accuracy += max(0, acc_f(predictions[column][i], true_values[i]))
         else:
             # For the T+1 usecase
-            accuracy = max(0, acc_f([x[0] for x in predictions[column]], true_values))
-            return accuracy
-
-    accuracy = accuracy / len(predictions[column])
-    return accuracy
+            return max(0, acc_f([x[0] for x in predictions[column]], true_values))
+    return accuracy / len(predictions[column])
 
 
 def evaluate_accuracy(predictions, data_frame, col_stats, output_columns, backend=None, **kwargs):

--- a/mindsdb_native/libs/helpers/general_helpers.py
+++ b/mindsdb_native/libs/helpers/general_helpers.py
@@ -197,7 +197,7 @@ def evaluate_regression_accuracy(
         **kwargs
     ):
     r2 = r2_score(true_values, predictions[column])
-    return r2 if r2 > 0 else 0
+    return max(r2, 0)
 
 
 def evaluate_classification_accuracy(column, predictions, true_values, **kwargs):
@@ -223,13 +223,13 @@ def evaluate_array_accuracy(column, predictions, true_values, **kwargs):
     acc_f = balanced_accuracy_score if kwargs['categorical'] else r2_score
     for i in range(len(predictions[column])):
         if isinstance(true_values[i],list):
-            accuracy += acc_f(predictions[column][i],true_values[i])
+            acc = max(0, acc_f(predictions[column][i], true_values[i]))
         else:
             # For the T+1 usecase
-            accuracy = acc_f([x[0] for x in predictions[column]], true_values)
+            accuracy = max(0, acc_f([x[0] for x in predictions[column]], true_values))
             return accuracy
 
-    accuracy = accuracy/len(predictions[column])
+    accuracy = accuracy / len(predictions[column])
     return accuracy
 
 
@@ -261,6 +261,7 @@ def evaluate_accuracy(predictions, data_frame, col_stats, output_columns, backen
         column_scores.append(column_score)
 
     score = sum(column_scores) / len(column_scores) if column_scores else 0.0
+
     if score == 0:
         score = 0.00000001
     return score

--- a/mindsdb_native/libs/helpers/general_helpers.py
+++ b/mindsdb_native/libs/helpers/general_helpers.py
@@ -194,18 +194,9 @@ def evaluate_regression_accuracy(
         predictions,
         true_values,
         backend,
-        use_conf_intervals=True,
         **kwargs
     ):
-    if use_conf_intervals:
-        pred_confidence_intervals = predictions[f'{column}_confidence_range']
-        within_interval = 0
-        for true, interval in zip(true_values, pred_confidence_intervals):
-            if true >= interval[0] and true <= interval[1]:
-                within_interval += 1
-        return within_interval/len(true_values)
-    else:
-        return r2_score(true_values, predictions[column])
+    return r2_score(true_values, predictions[column])
 
 
 def evaluate_classification_accuracy(column, predictions, true_values, **kwargs):

--- a/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
+++ b/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
@@ -16,7 +16,6 @@ from nonconformist.nc import RegressorNc, AbsErrorErrFunc, ClassifierNc, Inverse
 
 
 class ModelAnalyzer(BaseModule):
-
     def run(self):
         np.seterr(divide='warn', invalid='warn')
         """

--- a/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
+++ b/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
@@ -99,14 +99,12 @@ class ModelAnalyzer(BaseModule):
                 backend=self.transaction.model_backend
             )
 
-
         # Get some information about the importance of each column
         self.transaction.lmd['column_importances'] = {}
         for col in ignorable_input_columns:
             accuracy_increase = (normal_accuracy - empty_input_accuracy[col])
             # normalize from 0 to 10
             self.transaction.lmd['column_importances'][col] = 10 * max(0, accuracy_increase)
-            assert self.transaction.lmd['column_importances'][col] >= 0
             assert self.transaction.lmd['column_importances'][col] <= 10
 
         # Get accuracy stats
@@ -307,4 +305,3 @@ class ModelAnalyzer(BaseModule):
                     ,'confidence': deepcopy(None if confidence_ranges is None else confidence_ranges[0:200])
                     ,'order_by': deepcopy(list(validation_df[self.transaction.lmd['tss']['order_by'][0]])[0:200])
                 }
-                print(self.transaction.lmd['test_data_plot'][col])

--- a/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
+++ b/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
@@ -105,7 +105,14 @@ class ModelAnalyzer(BaseModule):
         for col in ignorable_input_columns:
             accuracy_increase = (normal_accuracy - empty_input_accuracy[col])
             # normalize from 0 to 10
-            self.transaction.lmd['column_importances'][col] = 10 * max(0, accuracy_increase)
+            if self.transaction.lmd['stats_v2'][col]['typing']['data_type'] == DATA_TYPES.NUMERIC:
+                # in case of numeric data type accuracy_increace can be greater
+                # than 1.0 because numerical accuracy is computed with r2_score
+                self.transaction.lmd['column_importances'][col] = 10 * min(max(0, accuracy_increase), 1.0)
+            else:
+                self.transaction.lmd['column_importances'][col] = 10 * max(0, accuracy_increase)
+            assert self.transaction.lmd['column_importances'][col] >= 0
+            assert self.transaction.lmd['column_importances'][col] <= 10
 
         # Get accuracy stats
         overall_accuracy_arr = []

--- a/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
+++ b/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
@@ -409,8 +409,7 @@ class LightwoodBackend:
                 self.transaction.input_data.validation_df[self.transaction.input_data.validation_df['make_predictions'].astype(bool) == True] if self.transaction.lmd['tss']['is_timeseries'] else self.transaction.input_data.validation_df,
                 self.transaction.lmd['stats_v2'],
                 self.transaction.lmd['predict_columns'],
-                backend=self,
-                use_conf_intervals=False # r2_score will be used for regression
+                backend=self
             )
 
             predictors_and_accuracies.append((

--- a/tests/integration_tests/flows/quick_interface.py
+++ b/tests/integration_tests/flows/quick_interface.py
@@ -32,3 +32,20 @@ class TestQuickInterface(unittest.TestCase):
         for pred in predictions['hours-per-week']:
             assert isinstance(pred,int)
             assert pred > 0
+
+    def test_quick_predict_output(self):
+        df = pd.DataFrame({
+            'x1': [x for x in range(100)],
+            'x2': [x*2 for x in range(100)],
+            'y': [y*3 for y in range(100)]
+        })
+
+        p1 = mindsdb_native.Predictor(name='test1')
+        p1.learn(from_data=df, to_predict='y')
+        pred1 = p1.predict(when_data={'x1': 3, 'x2': 5})
+
+        p2 = mindsdb_native.Predictor(name='test2')
+        p2.quick_learn(from_data=df, to_predict='y')
+        pred2 = p2.predict(when_data={'x1': 3, 'x2': 5})
+
+        assert set(pred1.keys()) == set(pred2.keys())

--- a/tests/integration_tests/flows/quick_interface.py
+++ b/tests/integration_tests/flows/quick_interface.py
@@ -27,7 +27,7 @@ class TestQuickInterface(unittest.TestCase):
         assert test_predictor.report_uuid == 'no_report'
 
         # Make some predictions with quick_predict and make sure they look alright
-        predictions = test_predictor.quick_predict(df_test)
+        predictions = test_predictor.predict(df_test)
         assert len(predictions['hours-per-week']) == len(df_test)
         for pred in predictions['hours-per-week']:
             assert isinstance(pred,int)

--- a/tests/integration_tests/flows/quick_interface.py
+++ b/tests/integration_tests/flows/quick_interface.py
@@ -42,10 +42,14 @@ class TestQuickInterface(unittest.TestCase):
 
         p1 = mindsdb_native.Predictor(name='test1')
         p1.learn(from_data=df, to_predict='y')
-        pred1 = p1.predict(when_data={'x1': 3, 'x2': 5})
+        pred1_1 = p1.predict(when_data={'x1': 3, 'x2': 5})
+        pred1_2 = p1.quick_predict(when_data={'x1': 3, 'x2': 5})
 
         p2 = mindsdb_native.Predictor(name='test2')
         p2.quick_learn(from_data=df, to_predict='y')
-        pred2 = p2.predict(when_data={'x1': 3, 'x2': 5})
+        pred2_1 = p2.predict(when_data={'x1': 3, 'x2': 5})
+        pred2_2 = p2.quick_predict(when_data={'x1': 3, 'x2': 5})
 
-        assert set(pred1.keys()) == set(pred2.keys())
+        assert set(pred1_1.keys()) == set(pred2_1.keys())
+        assert isinstance(pred1_2, dict)
+        assert isinstance(pred2_2, dict)

--- a/tests/unit_tests/libs/helpers/test_general_helpers.py
+++ b/tests/unit_tests/libs/helpers/test_general_helpers.py
@@ -5,6 +5,7 @@ from mindsdb_native.libs.helpers.general_helpers import (evaluate_accuracy)
 
 
 class TestEvaluateAccuracy(unittest.TestCase):
+    @unittest.skip('regression accuracy based on confidence range is removed')
     def test_evaluate_regression(self):
         predictions = {
             'y': [1, 2, 3, 4],
@@ -47,6 +48,7 @@ class TestEvaluateAccuracy(unittest.TestCase):
 
         assert round(accuracy, 2) == 0.75
 
+    @unittest.skip('regression accuracy based on confidence range is removed')
     def test_evaluate_two_columns(self):
         predictions = {
             'y1': [1, 2, 3, 4],
@@ -72,6 +74,7 @@ class TestEvaluateAccuracy(unittest.TestCase):
 
         assert round(accuracy, 2) == round((0.75 + 0.5)/2, 2)
 
+    @unittest.skip('regression accuracy based on confidence range is removed')
     def test_evaluate_array(self):
         predictions = {
             'y': [[1], [2], [3], [4]]
@@ -107,7 +110,7 @@ class TestEvaluateAccuracy(unittest.TestCase):
             (DATA_TYPES.FILE_PATH, None)
         ]:
             predictions = {
-                'y': ["1", "2", "3", "4"]
+                'y': ['1', '2', '3', '4']
             }
 
             col_stats = {
@@ -117,7 +120,7 @@ class TestEvaluateAccuracy(unittest.TestCase):
 
             output_columns = ['y']
 
-            data_frame = pd.DataFrame({'y': ["1", "2", "3", "5"]})
+            data_frame = pd.DataFrame({'y': ['1', '2', '3', '5']})
 
             accuracy = evaluate_accuracy(predictions, data_frame, col_stats,
                                          output_columns)

--- a/tests/unit_tests/libs/helpers/test_general_helpers.py
+++ b/tests/unit_tests/libs/helpers/test_general_helpers.py
@@ -100,7 +100,7 @@ class TestEvaluateAccuracy(unittest.TestCase):
 
         accuracy = evaluate_accuracy(predictions, data_frame, col_stats, output_columns)
 
-        assert round(accuracy, 2)  == 0.8
+        assert round(accuracy, 2) == 0.8
 
     def test_evaluate_weird_data_types(self):
         for dtype, data_subtype in [

--- a/tests/unit_tests/libs/helpers/test_general_helpers.py
+++ b/tests/unit_tests/libs/helpers/test_general_helpers.py
@@ -74,7 +74,6 @@ class TestEvaluateAccuracy(unittest.TestCase):
 
         assert round(accuracy, 2) == round((0.75 + 0.5)/2, 2)
 
-    @unittest.skip('regression accuracy based on confidence range is removed')
     def test_evaluate_array(self):
         predictions = {
             'y': [[1], [2], [3], [4]]


### PR DESCRIPTION
Closes https://github.com/mindsdb/mindsdb_native/issues/139
Closes https://github.com/mindsdb/mindsdb_native/issues/338

- Quick learn is enabled when data has too many columns
- Remove `quick_predict` method. Now, if you trained predictor with `Predictor.quick_learn`, `Predictor.predict` will have `advanced_args['quick_predict']` set to `True`.
- `evaluate_regression_accuracy` now only returns `r2_score`
- Fix output of `Predictor.predict` for models trained with `quck_learn`