### PR TITLE
Positive numerical tasks

### DIFF
--- a/mindsdb_native/libs/controllers/transaction.py
+++ b/mindsdb_native/libs/controllers/transaction.py
@@ -379,7 +379,12 @@ class PredictTransaction(Transaction):
                                 diff = sample[1, idx] - sample[0, idx]
                                 if diff <= tolerance:
                                     output_data[f'{predicted_col}_confidence'][sample_idx] = significance
-                                    output_data[f'{predicted_col}_confidence_range'][sample_idx] = list(sample[:, idx])
+                                    conf_range = list(sample[:, idx])
+
+                                    # for positive numerical domains
+                                    if self.lmd['stats_v2'][predicted_col].get('positive_domain', False):
+                                        conf_range[0] = max(0, conf_range[0])
+                                    output_data[f'{predicted_col}_confidence_range'][sample_idx] = conf_range
                                     break
                             else:
                                 output_data[f'{predicted_col}_confidence'][sample_idx] = 0.9901  # default

--- a/mindsdb_native/libs/phases/data_analyzer/data_analyzer.py
+++ b/mindsdb_native/libs/phases/data_analyzer/data_analyzer.py
@@ -299,18 +299,22 @@ class DataAnalyzer(BaseModule):
                     stats_v2[col_name]['bias']['warning'] = warning_str + " This doesn't necessarily mean there's an issue with your data, it just indicates a higher than usual probability there might be some issue."
 
                 if data_type == DATA_TYPES.NUMERIC:
-                        outliers = lof_outliers(data_subtype, col_data)
-                        stats_v2[col_name]['outliers'] = {
-                            'outlier_values': outliers,
-                            'outlier_buckets': compute_outlier_buckets(
-                                outlier_values=outliers,
-                                hist_x=histogram['x'],
-                                hist_y=histogram['y'],
-                                percentage_buckets=percentage_buckets,
-                                col_stats=stats_v2[col_name]
-                            ),
-                            'description': """Potential outliers can be thought as the "extremes", i.e., data points that are far from the center of mass (mean/median/interquartile range) of the data."""
-                        }
+                    outliers = lof_outliers(data_subtype, col_data)
+                    stats_v2[col_name]['outliers'] = {
+                        'outlier_values': outliers,
+                        'outlier_buckets': compute_outlier_buckets(
+                            outlier_values=outliers,
+                            hist_x=histogram['x'],
+                            hist_y=histogram['y'],
+                            percentage_buckets=percentage_buckets,
+                            col_stats=stats_v2[col_name]
+                        ),
+                        'description': """Potential outliers can be thought as the "extremes", i.e., data points that are far from the center of mass (mean/median/interquartile range) of the data."""
+                    }
+                    # specify positive numerical domain
+                    if stats_v2[col_name]['histogram']['x'][0] >= 0:
+                        stats_v2[col_name]['positive_domain'] = True
+
 
             if data_type == DATA_TYPES.TEXT:
                 lang_dist = get_language_dist(col_data)
@@ -326,7 +330,6 @@ class DataAnalyzer(BaseModule):
                 if isinstance(x, dict) and 'warning' in x:
                     self.log.warning(x['warning'])
                 stats_v2[col_name]['nr_warnings'] += 1
-            self.log.info(f'Finished analyzing column: {col_name} !\n')
 
             if data_type == DATA_TYPES.CATEGORICAL:
                 if data_subtype == DATA_SUBTYPES.TAGS:
@@ -344,6 +347,8 @@ class DataAnalyzer(BaseModule):
             if data_type == DATA_TYPES.CATEGORICAL:
                 if DATA_TYPES.NUMERIC in stats_v2[col_name]['additional_info']['other_potential_types']:
                     stats_v2[col_name]['typing']['alias'] = DATA_TYPE_ALIASES.NUMERICAL_LOW_GRANULARITY
+
+            self.log.info(f'Finished analyzing column: {col_name} !\n')
 
         self.transaction.lmd['data_preparation']['accepted_margin_of_error'] = self.transaction.lmd['sample_settings']['sample_margin_of_error']
 

--- a/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
+++ b/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
@@ -166,6 +166,8 @@ class LightwoodBackend:
             other_keys = {'encoder_attrs': {}}
             if data_type == DATA_TYPES.NUMERIC:
                 lightwood_data_type = ColumnDataTypes.NUMERIC
+                if col_name in self.transaction.lmd['predict_columns'] and col_stats.get('positive_domain', False):
+                    other_keys['encoder_attrs']['positive_domain'] = True
 
             elif data_type == DATA_TYPES.CATEGORICAL:
                 if data_subtype == DATA_SUBTYPES.TAGS:

--- a/tests/unit_tests/libs/controllers/test_predictor.py
+++ b/tests/unit_tests/libs/controllers/test_predictor.py
@@ -270,6 +270,13 @@ class TestPredictor(unittest.TestCase):
             assert isinstance(importance, (float, int))
             assert (importance >= 0 and importance <= 10)
 
+        # Check whether positive numerical domain was detected
+        assert self.predictor.transaction['lmd']['stats_v2']['rental_price']['positive_domain']
+
+        # Check no negative predictions are emitted
+        neg_pred_candidate = predictor.predict(when_data={'initial_price': -10}, use_gpu=use_gpu)
+        assert neg_pred_candidate._data['rental_price'] >= 0
+
         # Test confidence estimation after save -> load
         F.export_predictor(name)
         try:

--- a/tests/unit_tests/libs/controllers/test_predictor.py
+++ b/tests/unit_tests/libs/controllers/test_predictor.py
@@ -277,6 +277,8 @@ class TestPredictor(unittest.TestCase):
         for i in (-500, -100, -10):
             neg_pred_candidate = predictor.predict(when_data={'initial_price': i}, use_gpu=use_gpu)
             assert neg_pred_candidate._data['rental_price'][0] >= 0
+            assert neg_pred_candidate._data['rental_price_confidence_range'][0][0] >= 0
+            assert neg_pred_candidate._data['rental_price_confidence_range'][0][1] >= 0
 
         # Test confidence estimation after save -> load
         F.export_predictor(name)

--- a/tests/unit_tests/libs/controllers/test_predictor.py
+++ b/tests/unit_tests/libs/controllers/test_predictor.py
@@ -208,27 +208,24 @@ class TestPredictor(unittest.TestCase):
         Tests whole pipeline from downloading the dataset to making predictions and explanations.
         """
         predictor = Predictor(name=name)
-
-        path = '/MindsDB/benchmarks/benchmarks/datasets/home_rentals/data.csv'
-
         # Create & Learn
         predictor.learn(
             to_predict='rental_price',
-            from_data=path,#"https://s3.eu-west-2.amazonaws.com/mindsdb-example-data/home_rentals.csv",
+            from_data="https://s3.eu-west-2.amazonaws.com/mindsdb-example-data/home_rentals.csv",
             backend='lightwood',
             stop_training_in_x_seconds=80,
             use_gpu=use_gpu
         )
 
         test_results = predictor.test(
-            when_data=path,#"https://s3.eu-west-2.amazonaws.com/mindsdb-example-data/home_rentals.csv",
+            when_data="https://s3.eu-west-2.amazonaws.com/mindsdb-example-data/home_rentals.csv",
             accuracy_score_functions=r2_score,
             predict_args={'use_gpu': use_gpu}
         )
         assert test_results['rental_price_accuracy'] >= 0.8
 
         predictions = predictor.predict(
-            when_data=path,#"https://s3.eu-west-2.amazonaws.com/mindsdb-example-data/home_rentals.csv",
+            when_data="https://s3.eu-west-2.amazonaws.com/mindsdb-example-data/home_rentals.csv",
             use_gpu=use_gpu
         )
         self.assert_prediction_interface(predictions)


### PR DESCRIPTION
Avoid negative predictions for positive numerical targets by:
- Detecting positive numerical domains based on histogram
- Sending corresponding flag to Lightwood numerical encoder (see [this PR](https://github.com/mindsdb/lightwood/pull/318))

The PR also adds a small test to detect if this is working as intended.
