### PR TITLE
"Apply function to column" advanced argument

### DIFF
--- a/mindsdb_native/libs/controllers/predictor.py
+++ b/mindsdb_native/libs/controllers/predictor.py
@@ -258,7 +258,8 @@ class Predictor:
                 debug = advanced_args.get('debug', False),
                 allow_incomplete_history = advanced_args.get('allow_incomplete_history', False),
                 quick_learn = advanced_args.get('quick_learn', False),
-                quick_predict = advanced_args.get('quick_predict', False)
+                quick_predict = advanced_args.get('quick_predict', False),
+                apply_to_columns = advanced_args.get('apply_to_columns', {})
             )
 
             if rebuild_model is False:

--- a/mindsdb_native/libs/phases/data_extractor/data_extractor.py
+++ b/mindsdb_native/libs/phases/data_extractor/data_extractor.py
@@ -58,6 +58,9 @@ class DataExtractor(BaseModule):
         :return:
         """
 
+        for col, f in self.transaction.lmd['apply_to_columns']:
+            df.loc[col] = df.loc[col].apply(f)
+
         # apply order by (group_by, order_by)
         if self.transaction.lmd['tss']['is_timeseries']:
             asc_values = [True for _ in self.transaction.lmd['tss']['order_by']]

--- a/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
+++ b/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
@@ -16,13 +16,11 @@ from nonconformist.nc import RegressorNc, AbsErrorErrFunc, ClassifierNc, Inverse
 
 
 class ModelAnalyzer(BaseModule):
-
     def run(self):
         np.seterr(divide='warn', invalid='warn')
         """
         # Runs the model on the validation set in order to evaluate the accuracy and confidence of future predictions
         """
-
         validation_df = self.transaction.input_data.validation_df
         if self.transaction.lmd['tss']['is_timeseries']:
             validation_df = self.transaction.input_data.validation_df[self.transaction.input_data.validation_df['make_predictions'] == True]
@@ -98,6 +96,7 @@ class ModelAnalyzer(BaseModule):
                 backend=self.transaction.model_backend
             )
 
+
         # Get some information about the importance of each column
         self.transaction.lmd['column_importances'] = {}
         for col in ignorable_input_columns:
@@ -170,7 +169,7 @@ class ModelAnalyzer(BaseModule):
             self.transaction.lmd['accuracy_samples'][col] = accuracy_samples
             self.transaction.hmd['acc_stats'][col] = pickle_obj(acc_stats)
 
-        self.transaction.lmd['validation_set_accuracy'] = sum(overall_accuracy_arr)/len(overall_accuracy_arr)
+        self.transaction.lmd['validation_set_accuracy'] = sum(overall_accuracy_arr) / len(overall_accuracy_arr)
 
         # conformal prediction confidence estimation
         self.transaction.lmd['stats_v2']['train_std_dev'] = {}

--- a/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
+++ b/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
@@ -72,10 +72,12 @@ class LightwoodBackend:
         else:
             df_arr = [original_df]
 
+        df_arr = [dataframe.astype(object) for dataframe in df_arr]
+
         # Make type `object` so that dataframe cells can be python lists
         for i in range(len(df_arr)):
             for hist_col in ob_arr + self.transaction.lmd['tss']['historical_columns']:
-                df_arr[i][hist_col] = df_arr[i][hist_col].astype(object)
+                df_arr[i].loc[hist_col] = df_arr[i][hist_col].astype(object)
 
         # Make all order column cells lists
         for i in range(len(df_arr)):

--- a/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
+++ b/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
@@ -72,19 +72,19 @@ class LightwoodBackend:
         else:
             df_arr = [original_df]
 
-        df_arr = [dataframe.astype(object) for dataframe in df_arr]
+        #df_arr = [dataframe.astype(object) for dataframe in df_arr]
 
         # Make type `object` so that dataframe cells can be python lists
         for i in range(len(df_arr)):
             for hist_col in ob_arr + self.transaction.lmd['tss']['historical_columns']:
-                df_arr[i].loc[hist_col] = df_arr[i][hist_col].astype(object)
+                df_arr[i].loc[:, hist_col] = df_arr[i][hist_col].astype(object)
 
         # Make all order column cells lists
         for i in range(len(df_arr)):
             for order_col in ob_arr + self.transaction.lmd['tss']['historical_columns']:
                 for ii in range(len(df_arr[i])):
                     try:
-                        df_arr[i][order_col].iloc[ii] = [df_arr[i][order_col].iloc[ii]]
+                        df_arr[i].iloc[ii, order_col] = [df_arr[i][order_col].iloc[ii]]
                     except Exception:
                         # Needed because of a pandas bug that causes above to fail for small dataframes
                         label = df_arr[i].index.values[ii]
@@ -107,6 +107,9 @@ class LightwoodBackend:
                         [0] * (1 + window - len(df_arr[n].iloc[i][order_col]))
                     )
                     df_arr[n].iloc[i][order_col].reverse()
+
+        
+
 
         if self.transaction.lmd['tss']['use_previous_target']:
             for target_column in self.transaction.lmd['predict_columns']:

--- a/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
+++ b/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
@@ -13,7 +13,7 @@ from mindsdb_native.libs.helpers.general_helpers import evaluate_accuracy
 
 
 def _make_pred(row):
-    return not hasattr(row, "make_predictions") or row.make_predictions
+    return not hasattr(row, 'make_predictions') or row.make_predictions
 
 
 class LightwoodBackend:
@@ -72,8 +72,6 @@ class LightwoodBackend:
         else:
             df_arr = [original_df]
 
-        #df_arr = [dataframe.astype(object) for dataframe in df_arr]
-
         # Make type `object` so that dataframe cells can be python lists
         for i in range(len(df_arr)):
             for hist_col in ob_arr + self.transaction.lmd['tss']['historical_columns']:
@@ -83,12 +81,9 @@ class LightwoodBackend:
         for i in range(len(df_arr)):
             for order_col in ob_arr + self.transaction.lmd['tss']['historical_columns']:
                 for ii in range(len(df_arr[i])):
-                    try:
-                        df_arr[i].loc[ii, order_col] = [df_arr[i][order_col].iloc[ii]]
-                    except Exception:
-                        # Needed because of a pandas bug that causes above to fail for small dataframes
-                        label = df_arr[i].index.values[ii]
-                        df_arr[i].at[label, order_col] = [df_arr[i].at[label, order_col]]
+                    # Needed because of a pandas bug that causes above to fail for small dataframes
+                    label = df_arr[i].index.values[ii]
+                    df_arr[i].at[label, order_col] = [df_arr[i].at[label, order_col]]
 
         # Add previous rows
         for n in range(len(df_arr)):
@@ -97,8 +92,8 @@ class LightwoodBackend:
                     previous_indexes = [*range(max(0, i - window), i)]
 
                     for prev_i in reversed(previous_indexes):
-                        df_arr[n][order_col].iloc[i].append(
-                            df_arr[n][order_col].iloc[prev_i][-1]
+                        df_arr[n].iloc[i][order_col].append(
+                            df_arr[n].iloc[prev_i][order_col][-1]
                         )
 
                     # Zero pad
@@ -107,9 +102,6 @@ class LightwoodBackend:
                         [0] * (1 + window - len(df_arr[n].iloc[i][order_col]))
                     )
                     df_arr[n].iloc[i][order_col].reverse()
-
-        
-
 
         if self.transaction.lmd['tss']['use_previous_target']:
             for target_column in self.transaction.lmd['predict_columns']:
@@ -120,7 +112,7 @@ class LightwoodBackend:
 
                     previous_target_values_arr = []
                     for i in range(len(previous_target_values)):
-                        arr = previous_target_values[max(i-window,0):i+1]
+                        arr = previous_target_values[max(i - window, 0):i + 1]
                         while len(arr) <= window:
                             arr = [None] + arr
                         previous_target_values_arr.append(arr)
@@ -128,15 +120,13 @@ class LightwoodBackend:
                     df_arr[k][f'__mdb_ts_previous_{target_column}'] = previous_target_values_arr
                     for timestep_index in range(1, self.nr_predictions):
                         next_target_value_arr = list(df_arr[k][target_column])
-                        for del_index in range(0,timestep_index):
+                        for del_index in range(0, timestep_index):
                             del next_target_value_arr[del_index]
                             next_target_value_arr.append(0)
                         # @TODO: Maybe ignore the rows with `None` next targets for training
                         df_arr[k][f'{target_column}_timestep_{timestep_index}'] = next_target_value_arr
 
-
         combined_df = pd.concat(df_arr)
-
 
         if 'make_predictions' in combined_df.columns:
             combined_df = pd.DataFrame(combined_df[combined_df['make_predictions'].astype(bool) == True])

--- a/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
+++ b/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
@@ -84,7 +84,7 @@ class LightwoodBackend:
             for order_col in ob_arr + self.transaction.lmd['tss']['historical_columns']:
                 for ii in range(len(df_arr[i])):
                     try:
-                        df_arr[i].iloc[ii, order_col] = [df_arr[i][order_col].iloc[ii]]
+                        df_arr[i].loc[ii, order_col] = [df_arr[i][order_col].iloc[ii]]
                     except Exception:
                         # Needed because of a pandas bug that causes above to fail for small dataframes
                         label = df_arr[i].index.values[ii]

--- a/tests/unit_tests/libs/controllers/test_predictor.py
+++ b/tests/unit_tests/libs/controllers/test_predictor.py
@@ -284,7 +284,7 @@ class TestPredictor(unittest.TestCase):
         F.export_predictor(name)
         try:
             F.delete_model(f'{name}-new')
-        except:
+        except Exception:
             pass
         F.import_model(f'{name}.zip', f'{name}-new')
         p = Predictor(name=f'{name}-new')


### PR DESCRIPTION
in **arrivals** (https://github.com/mindsdb/private-benchmarks/tree/master/benchmarks/datasets/arrivals) dataset,

```
1982-1
1982-2
1982-10
```

would be sorted to
```
1982-1
1982-10
1982-2
```

with "apply_to_columns" advanced argument you can define how you want to treat this column is it will be sorted the right way:
```
1982-1
1982-2
1982-10
```

