### PR TITLE
Remove 'save_path' from lmd

### DIFF
--- a/mindsdb_native/libs/controllers/functional.py
+++ b/mindsdb_native/libs/controllers/functional.py
@@ -167,11 +167,6 @@ def rename_model(old_model_name, new_model_name):
         lmd['name'] = new_model_name
         hmd['name'] = new_model_name
 
-        try:
-            lmd['lightwood_data']['save_path'] = lmd['lightwood_data'][
-                'save_path'].replace(old_model_name, new_model_name)
-        except Exception:
-            return False
 
         with open(os.path.join(CONFIG.MINDSDB_STORAGE_PATH,
                             new_model_name, 'light_model_metadata.pickle'),
@@ -198,13 +193,6 @@ def delete_model(model_name):
     :return: bool (True/False) True if model was deleted
     """
     with MDBLock('exclusive', 'delete_' + model_name):
-        lmd = load_lmd(os.path.join(CONFIG.MINDSDB_STORAGE_PATH, model_name, 'light_model_metadata.pickle'))
-
-        try:
-            os.remove(lmd['lightwood_data']['save_path'])
-        except Exception:
-            pass
-
         shutil.rmtree(os.path.join(CONFIG.MINDSDB_STORAGE_PATH, model_name))
 
 
@@ -239,9 +227,6 @@ def import_model(model_archive_path, new_name=None):
     )
 
     with MDBLock('exclusive', 'detele_' + lmd['name']):
-        if 'lightwood_data' in lmd and 'save_path' in lmd['lightwood_data']:
-            lmd['lightwood_data']['save_path'] = os.path.join(CONFIG.MINDSDB_STORAGE_PATH, lmd['name'], 'lightwood_data')
-
         with open(os.path.join(CONFIG.MINDSDB_STORAGE_PATH, lmd['name'], 'light_model_metadata.pickle'), 'wb') as fp:
             pickle.dump(lmd, fp,protocol=pickle.HIGHEST_PROTOCOL)
 

--- a/mindsdb_native/libs/controllers/transaction.py
+++ b/mindsdb_native/libs/controllers/transaction.py
@@ -88,7 +88,7 @@ class Transaction:
                     try:
                         self.hmd['icp'][col].nc_function.model.model = self.session.transaction.model_backend.predictor
                     except AttributeError:
-                        model_path = self.lmd['lightwood_data']['save_path']
+                        model_path = os.path.join(CONFIG.MINDSDB_STORAGE_PATH, self.hmd['name'], 'lightwood_data')
                         self.hmd['icp'][col].nc_function.model.model = Predictor(load_from_path=model_path)
         except FileNotFoundError as e:
             self.hmd['icp'] = {'active': False}

--- a/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
+++ b/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
@@ -327,7 +327,6 @@ class LightwoodBackend:
         )
         lightwood_test_ds = lightwood_train_ds.make_child(test_df)
 
-        self.transaction.lmd['lightwood_data']['save_path'] = os.path.join(CONFIG.MINDSDB_STORAGE_PATH, self.transaction.lmd['name'], 'lightwood_data')
         Path(CONFIG.MINDSDB_STORAGE_PATH).joinpath(self.transaction.lmd['name']).mkdir(mode=0o777, exist_ok=True, parents=True)
 
         logging.getLogger().setLevel(logging.DEBUG)
@@ -446,7 +445,8 @@ class LightwoodBackend:
             if (best_accuracy - nn_mixer_predictor_accuracy) < SMALL_ACCURACY_DIFFERENCE:
                 self.predictor = nn_mixer_predictor
 
-        self.predictor.save(path_to=self.transaction.lmd['lightwood_data']['save_path'])
+        save_path = os.path.join(CONFIG.MINDSDB_STORAGE_PATH, self.transaction.lmd['name'], 'lightwood_data')
+        self.predictor.save(path_to=save_path)
 
     def predict(self, mode='predict', ignore_columns=None, all_mixers=False):
         if ignore_columns is None:
@@ -470,7 +470,8 @@ class LightwoodBackend:
             df, _, timeseries_row_mapping = self._ts_reshape(df)
 
         if self.predictor is None:
-            self.predictor = lightwood.Predictor(load_from_path=self.transaction.lmd['lightwood_data']['save_path'])
+            predictor_path = os.path.join(CONFIG.MINDSDB_STORAGE_PATH, self.transaction.lmd['name'], 'lightwood_data')
+            self.predictor = lightwood.Predictor(load_from_path=predictor_path)
 
         # not the most efficient but least prone to bug and should be fast enough
         if len(ignore_columns) > 0:


### PR DESCRIPTION
fix https://github.com/mindsdb/mindsdb/issues/979
Problem: if just copy/paste predictor to other folder, and use this folder as 'storage_path', then predictor will be nonfunctional because ldm['save_path'] point to other dir. Only one way was to copy predictors - export/import it through gui.
Since all predictor files stored in one folder, we dont need more 'save_path' in ldm.