### PR TITLE
Take out language analysis (temporarily)

### DIFF
--- a/mindsdb_native/libs/phases/data_analyzer/data_analyzer.py
+++ b/mindsdb_native/libs/phases/data_analyzer/data_analyzer.py
@@ -315,16 +315,6 @@ class DataAnalyzer(BaseModule):
                     if stats_v2[col_name]['histogram']['x'][0] >= 0:
                         stats_v2[col_name]['positive_domain'] = True
 
-
-            if data_type == DATA_TYPES.TEXT:
-                lang_dist = get_language_dist(col_data)
-                nr_words, word_dist, nr_words_dist = analyze_sentences(col_data)
-
-                stats_v2[col_name]['avg_words_per_sentence'] = nr_words / len(col_data)
-                stats_v2[col_name]['word_dist'] = shrink_word_dist(word_dist)
-                stats_v2[col_name]['nr_words_dist'] = nr_words_dist
-                stats_v2[col_name]['lang_dist'] = lang_dist
-
             stats_v2[col_name]['nr_warnings'] = 0
             for x in stats_v2[col_name].values():
                 if isinstance(x, dict) and 'warning' in x:

--- a/tests/unit_tests/libs/helpers/test_text_helpers.py
+++ b/tests/unit_tests/libs/helpers/test_text_helpers.py
@@ -13,6 +13,7 @@ from mindsdb_native.libs.helpers.text_helpers import get_identifier_description
 
 
 class TestTextHelpers(unittest.TestCase):
+    @unittest.skip('language analysis is temporarily not used')
     def test_language_analysis(self):
         SENTENCES = {
             'en': [
@@ -46,7 +47,6 @@ class TestTextHelpers(unittest.TestCase):
             assert 'Unknown' in lang_dist
             assert lang_dist['Unknown'] == 0
             assert lang_dist[lang] == len(SENTENCES[lang])
-
 
     def test_identifiers(self):
         N = 300


### PR DESCRIPTION
Closes https://github.com/mindsdb/mindsdb_native/issues/336

- Don't compute language stats for text data type
- Skip language analysis tests

The following keys are removed from stats_v2[col_name]
- `'avg_words_per_sentence'`
- `'word_dist'`
- `'nr_words_dist'`
- `'lang_dist'`