### PR TITLE
Two accuracy metrics for numerical predictions

### DIFF
--- a/mindsdb_native/libs/controllers/functional.py
+++ b/mindsdb_native/libs/controllers/functional.py
@@ -369,6 +369,11 @@ def get_model_data(model_name=None, lmd=None):
             else:
                 accuracy_samples = None
 
+            if 'normal_accuracy' in lmd and col in lmd['normal_accuracy']:
+                normal_accuracy = lmd['normal_accuracy'][col]
+            else:
+                normal_accuracy = None
+
             # Model analysis building for each of the predict columns
             mao = {
                 'column_name': col
@@ -394,6 +399,7 @@ def get_model_data(model_name=None, lmd=None):
               }
               ,"confusion_matrix": confusion_matrix
               ,"accuracy_samples": accuracy_samples
+              ,"normal_accuracy": normal_accuracy
             }
 
 

--- a/mindsdb_native/libs/controllers/functional.py
+++ b/mindsdb_native/libs/controllers/functional.py
@@ -325,6 +325,9 @@ def get_model_data(model_name=None, lmd=None):
         else:
             amd[k] = None
 
+    if 'validation_set_accuracy_r2' in lmd:
+        amd['accuracy_r2'] = lmd['validation_set_accuracy_r2']
+
     amd['data_analysis'] = {
         'target_columns_metadata': []
         ,'input_columns_metadata': []

--- a/mindsdb_native/libs/controllers/functional.py
+++ b/mindsdb_native/libs/controllers/functional.py
@@ -369,11 +369,6 @@ def get_model_data(model_name=None, lmd=None):
             else:
                 accuracy_samples = None
 
-            if 'normal_accuracy' in lmd and col in lmd['normal_accuracy']:
-                normal_accuracy = lmd['normal_accuracy'][col]
-            else:
-                normal_accuracy = None
-
             # Model analysis building for each of the predict columns
             mao = {
                 'column_name': col
@@ -399,7 +394,6 @@ def get_model_data(model_name=None, lmd=None):
               }
               ,"confusion_matrix": confusion_matrix
               ,"accuracy_samples": accuracy_samples
-              ,"normal_accuracy": normal_accuracy
             }
 
 

--- a/mindsdb_native/libs/controllers/predictor.py
+++ b/mindsdb_native/libs/controllers/predictor.py
@@ -140,7 +140,6 @@ class Predictor:
 
         return self.learn(to_predict, from_data, timeseries_settings, ignore_columns, stop_training_in_x_seconds, backend, rebuild_model, use_gpu, equal_accuracy_for_all_output_categories, output_categories_importance_dictionary, advanced_args, sample_settings)
 
-
     def learn(self,
               to_predict,
               from_data,

--- a/mindsdb_native/libs/helpers/general_helpers.py
+++ b/mindsdb_native/libs/helpers/general_helpers.py
@@ -261,7 +261,7 @@ def evaluate_accuracy(predictions,
             backend=backend,
             **kwargs
         )
-        column_scores[columns] = column_score
+        column_scores[column] = column_score
 
     if return_dict:
         pass

--- a/mindsdb_native/libs/helpers/general_helpers.py
+++ b/mindsdb_native/libs/helpers/general_helpers.py
@@ -237,7 +237,7 @@ def evaluate_accuracy(predictions,
                       backend=None,
                       return_dict=False,
                       **kwargs):
-    column_scores = {}
+    column_scores = []
     for column in output_columns:
         col_type = col_stats[column]['typing']['data_type']
         col_subtype = col_stats[column]['typing']['data_subtype']
@@ -261,13 +261,10 @@ def evaluate_accuracy(predictions,
             backend=backend,
             **kwargs
         )
-        column_scores[column] = column_score
+        column_scores.append(column_score)
 
-    if return_dict:
-        pass
-    else:
-        score = sum(column_scores.values()) / len(column_scores) if column_scores else 0.0
-        return 0.00000001 if score == 0 else score
+    score = sum(column_scores.values()) / len(column_scores) if column_scores else 0.0
+    return 0.00000001 if score == 0 else score
 
 
 class suppress_stdout_stderr(object):

--- a/mindsdb_native/libs/helpers/general_helpers.py
+++ b/mindsdb_native/libs/helpers/general_helpers.py
@@ -237,7 +237,7 @@ def evaluate_accuracy(predictions,
                       backend=None,
                       return_dict=False,
                       **kwargs):
-    column_scores = []
+    column_scores = {}
     for column in output_columns:
         col_type = col_stats[column]['typing']['data_type']
         col_subtype = col_stats[column]['typing']['data_subtype']

--- a/mindsdb_native/libs/helpers/general_helpers.py
+++ b/mindsdb_native/libs/helpers/general_helpers.py
@@ -267,10 +267,7 @@ def evaluate_accuracy(predictions,
         pass
     else:
         score = sum(column_scores.values()) / len(column_scores) if column_scores else 0.0
-
-        if score == 0:
-            score = 0.00000001
-        return score
+        return 0.00000001 if score == 0 else score
 
 
 class suppress_stdout_stderr(object):

--- a/mindsdb_native/libs/helpers/general_helpers.py
+++ b/mindsdb_native/libs/helpers/general_helpers.py
@@ -263,7 +263,7 @@ def evaluate_accuracy(predictions,
         )
         column_scores.append(column_score)
 
-    score = sum(column_scores.values()) / len(column_scores) if column_scores else 0.0
+    score = sum(column_scores) / len(column_scores) if column_scores else 0.0
     return 0.00000001 if score == 0 else score
 
 

--- a/mindsdb_native/libs/helpers/general_helpers.py
+++ b/mindsdb_native/libs/helpers/general_helpers.py
@@ -230,7 +230,13 @@ def evaluate_array_accuracy(column, predictions, true_values, **kwargs):
     return accuracy / len(predictions[column])
 
 
-def evaluate_accuracy(predictions, data_frame, col_stats, output_columns, backend=None, **kwargs):
+def evaluate_accuracy(predictions,
+                      data_frame,
+                      col_stats,
+                      output_columns,
+                      backend=None,
+                      return_dict=False,
+                      **kwargs):
     column_scores = []
     for column in output_columns:
         col_type = col_stats[column]['typing']['data_type']
@@ -255,13 +261,16 @@ def evaluate_accuracy(predictions, data_frame, col_stats, output_columns, backen
             backend=backend,
             **kwargs
         )
-        column_scores.append(column_score)
+        column_scores[columns] = column_score
 
-    score = sum(column_scores) / len(column_scores) if column_scores else 0.0
+    if return_dict:
+        pass
+    else:
+        score = sum(column_scores.values()) / len(column_scores) if column_scores else 0.0
 
-    if score == 0:
-        score = 0.00000001
-    return score
+        if score == 0:
+            score = 0.00000001
+        return score
 
 
 class suppress_stdout_stderr(object):

--- a/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
+++ b/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
@@ -182,8 +182,9 @@ class ModelAnalyzer(BaseModule):
             self.transaction.lmd['accuracy_samples'][col] = accuracy_samples
             self.transaction.hmd['acc_stats'][col] = pickle_obj(acc_stats)
 
-        self.transaction.lmd['validation_set_normal_accuracy'] = normal_accuracy
-        self.transaction.lmd['validation_set_confidence_accuracy'] = sum(overall_accuracy_arr) / len(overall_accuracy_arr)
+        self.transaction.lmd['validation_set_accuracy'] = normal_accuracy
+        if self.transaction.lmd['stats_v2'][col]['typing']['data_type'] == DATA_TYPES.NUMERIC:
+            self.transaction.lmd['validation_set_accuracy_accuracy_r2'] = normal_accuracy
 
         # conformal prediction confidence estimation
         self.transaction.lmd['stats_v2']['train_std_dev'] = {}

--- a/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
+++ b/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
@@ -49,6 +49,8 @@ class ModelAnalyzer(BaseModule):
         )
 
         normal_accuracy = sum(normal_accs.values()) / len(normal_accs)
+        if normal_accuracy == 0:
+            normal_accuracy = 0.00000001
 
         for col in output_columns:
             reals = validation_df[col]

--- a/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
+++ b/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
@@ -182,8 +182,8 @@ class ModelAnalyzer(BaseModule):
             self.transaction.lmd['accuracy_samples'][col] = accuracy_samples
             self.transaction.hmd['acc_stats'][col] = pickle_obj(acc_stats)
 
-        self.transaction.lmd['normal_accuracy'] = normal_accuracy
-        self.transaction.lmd['validation_set_accuracy'] = sum(overall_accuracy_arr) / len(overall_accuracy_arr)
+        self.transaction.lmd['validation_set_normal_accuracy'] = normal_accuracy
+        self.transaction.lmd['validation_set_confidence_accuracy'] = sum(overall_accuracy_arr) / len(overall_accuracy_arr)
 
         # conformal prediction confidence estimation
         self.transaction.lmd['stats_v2']['train_std_dev'] = {}

--- a/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
+++ b/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
@@ -39,18 +39,13 @@ class ModelAnalyzer(BaseModule):
         normal_predictions = self.transaction.model_backend.predict('validate')
         normal_predictions_test = self.transaction.model_backend.predict('test')
 
-        normal_accs = evaluate_accuracy(
+        normal_accuracy = evaluate_accuracy(
             normal_predictions,
             validation_df,
             self.transaction.lmd['stats_v2'],
             output_columns,
-            backend=self.transaction.model_backend,
-            return_dict=True
+            backend=self.transaction.model_backend
         )
-
-        normal_accuracy = sum(normal_accs.values()) / len(normal_accs)
-        if normal_accuracy == 0:
-            normal_accuracy = 0.00000001
 
         for col in output_columns:
             reals = validation_df[col]
@@ -186,8 +181,8 @@ class ModelAnalyzer(BaseModule):
             self.transaction.lmd['confusion_matrices'][col] = cm
             self.transaction.lmd['accuracy_samples'][col] = accuracy_samples
             self.transaction.hmd['acc_stats'][col] = pickle_obj(acc_stats)
-            self.transaction.lmd['normal_accuracy'] = normal_accs[col]
 
+        self.transaction.lmd['normal_accuracy'] = normal_accuracy
         self.transaction.lmd['validation_set_accuracy'] = sum(overall_accuracy_arr) / len(overall_accuracy_arr)
 
         # conformal prediction confidence estimation

--- a/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
+++ b/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
@@ -184,7 +184,7 @@ class ModelAnalyzer(BaseModule):
 
         self.transaction.lmd['validation_set_accuracy'] = normal_accuracy
         if self.transaction.lmd['stats_v2'][col]['typing']['data_type'] == DATA_TYPES.NUMERIC:
-            self.transaction.lmd['validation_set_accuracy_accuracy_r2'] = normal_accuracy
+            self.transaction.lmd['validation_set_accuracy_r2'] = normal_accuracy
 
         # conformal prediction confidence estimation
         self.transaction.lmd['stats_v2']['train_std_dev'] = {}

--- a/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
+++ b/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
@@ -165,10 +165,20 @@ class ModelAnalyzer(BaseModule):
             )
 
         for col in output_columns:
-            acc_stats = AccStats(col_stats=self.transaction.lmd['stats_v2'][col], col_name=col, input_columns=input_columns)
+            acc_stats = AccStats(
+                col_stats=self.transaction.lmd['stats_v2'][col],
+                col_name=col,
+                input_columns=input_columns
+            )
+
             predictions_arr = [normal_predictions_test] + [x for x in empty_input_predictions_test.values()]
 
-            acc_stats.fit(test_df, predictions_arr, [[ignored_column] for ignored_column in empty_input_predictions_test])
+            acc_stats.fit(
+                test_df,
+                predictions_arr,
+                [[ignored_column] for ignored_column in empty_input_predictions_test]
+            )
+
             overall_accuracy, accuracy_histogram, cm, accuracy_samples = acc_stats.get_accuracy_stats()
             overall_accuracy_arr.append(overall_accuracy)
 
@@ -252,7 +262,13 @@ class ModelAnalyzer(BaseModule):
                 if not is_classification:
                     self.transaction.lmd['stats_v2']['train_std_dev'][target] = self.transaction.input_data.train_df[target].std()
 
-                X = clean_df(X, self.transaction.lmd['stats_v2'], output_columns, fit_params['columns_to_ignore'])
+                X = clean_df(
+                    X,
+                    self.transaction.lmd['stats_v2'],
+                    output_columns,
+                    fit_params['columns_to_ignore']
+                )
+
                 self.transaction.hmd['icp'][target].index = X.columns
                 self.transaction.hmd['icp'][target].fit(X.values, y.values)
                 self.transaction.hmd['icp']['active'] = True
@@ -269,7 +285,13 @@ class ModelAnalyzer(BaseModule):
                         y = np.array([cats.index(i) for i in y])
                     y = y.astype(int)
 
-                X = clean_df(X, self.transaction.lmd['stats_v2'], output_columns, fit_params['columns_to_ignore'])
+                X = clean_df(
+                    X,
+                    self.transaction.lmd['stats_v2'],
+                    output_columns,
+                    fit_params['columns_to_ignore']
+                )
+
                 self.transaction.hmd['icp'][target].calibrate(X.values, y)
 
 

--- a/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
+++ b/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
@@ -39,13 +39,16 @@ class ModelAnalyzer(BaseModule):
         normal_predictions = self.transaction.model_backend.predict('validate')
         normal_predictions_test = self.transaction.model_backend.predict('test')
 
-        normal_accuracy = evaluate_accuracy(
+        normal_accs = evaluate_accuracy(
             normal_predictions,
             validation_df,
             self.transaction.lmd['stats_v2'],
             output_columns,
-            backend=self.transaction.model_backend
+            backend=self.transaction.model_backend,
+            return_dict=True
         )
+
+        normal_accuracy = sum(normal_accs.values()) / len(normal_accs)
 
         for col in output_columns:
             reals = validation_df[col]
@@ -171,6 +174,7 @@ class ModelAnalyzer(BaseModule):
             self.transaction.lmd['confusion_matrices'][col] = cm
             self.transaction.lmd['accuracy_samples'][col] = accuracy_samples
             self.transaction.hmd['acc_stats'][col] = pickle_obj(acc_stats)
+            self.transaction.lmd['normal_accuracy'] = normal_accs[col]
 
         self.transaction.lmd['validation_set_accuracy'] = sum(overall_accuracy_arr) / len(overall_accuracy_arr)
 

--- a/tests/unit_tests/libs/controllers/test_predictor.py
+++ b/tests/unit_tests/libs/controllers/test_predictor.py
@@ -242,7 +242,7 @@ class TestPredictor(unittest.TestCase):
         assert isinstance(amd['predict'], (list, str))
         assert isinstance(amd['is_active'], bool)
 
-        for k in ['validation_set_accuracy', 'accuracy']:
+        for k in ['validation_set_accuracy', 'validation_set_accuracy_r2']:
             assert isinstance(amd[k], float)
 
         for k in amd['data_preparation']:

--- a/tests/unit_tests/libs/controllers/test_predictor.py
+++ b/tests/unit_tests/libs/controllers/test_predictor.py
@@ -242,7 +242,7 @@ class TestPredictor(unittest.TestCase):
         assert isinstance(amd['predict'], (list, str))
         assert isinstance(amd['is_active'], bool)
 
-        for k in ['validation_set_accuracy', 'validation_set_accuracy_r2']:
+        for k in ['validation_set_accuracy', 'accuracy_r2']:
             assert isinstance(amd[k], float)
 
         for k in amd['data_preparation']:


### PR DESCRIPTION
Closes https://github.com/mindsdb/mindsdb_native/issues/339

- After training a predictor, store both confidence accuracy (computed with confidence ranges) and normal accuracy (computed with r2_score) in `transaction.lmd`
- `get_model_data` now has `accuracy_r2` key for numerical target