### PR TITLE
Take out language analysis

### DIFF
--- a/mindsdb_native/libs/helpers/text_helpers.py
+++ b/mindsdb_native/libs/helpers/text_helpers.py
@@ -76,17 +76,6 @@ def analyze_sentences(data):
     return nr_words, dict(word_dist), dict(nr_words_dist)
 
 
-def shrink_word_dist(word_dist, limit=50):
-    tiny_word_dist = dict(
-        sorted(
-            word_dist.items(),
-            key=lambda x: x[1]
-        )[:limit]
-    )
-    tiny_word_dist['other words'] = sum(word_dist.values()) - sum(tiny_word_dist.values())
-    return tiny_word_dist
-
-
 def word_tokenize(string):
     sep_tag = '{#SEP#}'
     for separator in WORD_SEPARATORS:

--- a/mindsdb_native/libs/phases/data_analyzer/data_analyzer.py
+++ b/mindsdb_native/libs/phases/data_analyzer/data_analyzer.py
@@ -15,10 +15,7 @@ from mindsdb_native.libs.constants.mindsdb import *
 from mindsdb_native.libs.phases.base_module import BaseModule
 from mindsdb_native.libs.helpers.text_helpers import (
     splitRecursive,
-    clean_float,
-    analyze_sentences,
-    get_language_dist,
-    shrink_word_dist
+    clean_float
 )
 
 from mindsdb_native.libs.constants.mindsdb import (
@@ -314,16 +311,6 @@ class DataAnalyzer(BaseModule):
                     # specify positive numerical domain
                     if stats_v2[col_name]['histogram']['x'][0] >= 0:
                         stats_v2[col_name]['positive_domain'] = True
-
-
-            if data_type == DATA_TYPES.TEXT:
-                lang_dist = get_language_dist(col_data)
-                nr_words, word_dist, nr_words_dist = analyze_sentences(col_data)
-
-                stats_v2[col_name]['avg_words_per_sentence'] = nr_words / len(col_data)
-                stats_v2[col_name]['word_dist'] = shrink_word_dist(word_dist)
-                stats_v2[col_name]['nr_words_dist'] = nr_words_dist
-                stats_v2[col_name]['lang_dist'] = lang_dist
 
             stats_v2[col_name]['nr_warnings'] = 0
             for x in stats_v2[col_name].values():


### PR DESCRIPTION
Closes https://github.com/mindsdb/mindsdb_native/issues/336

- Don't compute language stats for text data type

The following keys are removed from stats_v2[col_name]
- `'avg_words_per_sentence'`
- `'word_dist'`
- `'nr_words_dist'`
- `'lang_dist'`