### PR TITLE
MSSQL tests and fixes

### DIFF
--- a/mindsdb_native/libs/data_sources/ms_sql_ds.py
+++ b/mindsdb_native/libs/data_sources/ms_sql_ds.py
@@ -14,10 +14,8 @@ class MSSQLDS(SQLDataSource):
         self.password = password
 
     def query(self, q):
-        with pymssql.connect(server=self.host, user=self.user, password=self.password, database=self.database) as con:
+        with pymssql.connect(server=self.host, host=self.host, user=self.user, password=self.password, database=self.database, port=self.port) as con:
             df = pd.read_sql(q, con=con)
-        print(df)
-        exit()
         return df, self._make_colmap(df)
 
     def name(self):

--- a/mindsdb_native/libs/data_sources/ms_sql_ds.py
+++ b/mindsdb_native/libs/data_sources/ms_sql_ds.py
@@ -1,5 +1,5 @@
 import pandas as pd
-import pytds
+import pymssql
 from mindsdb_native.libs.data_types.data_source import SQLDataSource
 
 
@@ -7,15 +7,17 @@ class MSSQLDS(SQLDataSource):
     def __init__(self, query, database='master', host='localhost',
                port=1433, user='sa', password=''):
         super().__init__(query=query)
-        self.database_ = database
+        self.database = database
         self.host = host
         self.port = int(port)
         self.user = user
         self.password = password
 
     def query(self, q):
-        with pytds.connect(dsn=self.host, user=self.user, password=self.password, database=self.database) as con:
+        with pymssql.connect(server=self.host, user=self.user, password=self.password, database=self.database) as con:
             df = pd.read_sql(q, con=con)
+        print(df)
+        exit()
         return df, self._make_colmap(df)
 
     def name(self):

--- a/optional_requirements_extra_data_sources.txt
+++ b/optional_requirements_extra_data_sources.txt
@@ -1,6 +1,6 @@
 boto3 >= 1.9.0
 pg8000 >= 1.15.3
-python-tds >= 1.10.0
+pymssql >= 2.0.0
 pymongo >= 3.10.1
 PyAthena >= 1.11.2
 google-cloud-storage

--- a/tests/integration_tests/data_sources/test_ms_sql_ds.py
+++ b/tests/integration_tests/data_sources/test_ms_sql_ds.py
@@ -17,7 +17,7 @@ class TestMSSQL(unittest.TestCase):
         PORT = DB_CREDENTIALS['mssql']['port']
 
         mssql_ds = MSSQLDS(
-            query='SELECT * FROM dbo.insurance LIMIT 233',
+            query='SELECT * FROM dbo.insurance LIMIT',
             host=HOST,
             user=USER,
             password=PASSWORD,
@@ -25,5 +25,5 @@ class TestMSSQL(unittest.TestCase):
             port=PORT
         )
 
-        assert (len(mssql_ds.df) == 233)
-        F.analyse_dataset(from_data=mssql_ds)
+        assert (len(mssql_ds.df) > 200)
+        analysis = F.analyse_dataset(from_data=mssql_ds)

--- a/tests/integration_tests/data_sources/test_ms_sql_ds.py
+++ b/tests/integration_tests/data_sources/test_ms_sql_ds.py
@@ -7,27 +7,17 @@ from . import DB_CREDENTIALS, break_dataset
 
 
 class TestMSSQL(unittest.TestCase):
-    @unittest.skip('No remote MSSQL Server yet')
     def test_mssql_ds(self):
-        import pytds
         from mindsdb_native import MSSQLDS
 
-        HOST = 'localhost'
-        USER = 'sa'
-        PASSWORD = '123ABCdef@!'
-        DATABASE = 'master'
-        PORT = 1433
-
-        with pytds.connect(dsn=HOST, user=USER, password=PASSWORD, database=DATABASE) as con:
-            with con.cursor() as cur:
-                cur.execute("IF OBJECT_ID('dbo.test_mindsdb') IS NOT NULL DROP TABLE dbo.test_mindsdb")
-                cur.execute('CREATE TABLE test_mindsdb(col_1 Text, col_2 BIGINT, col_3 BIT)')
-                for i in range(0, 200):
-                    cur.execute(f"INSERT INTO test_mindsdb ([col_1], [col_2], [col_3]) VALUES ('This is string number {i}', {i}, {i % 2})")
-            con.commit()
+        HOST = DB_CREDENTIALS['mssql']['host']
+        USER = DB_CREDENTIALS['mssql']['user']
+        PASSWORD = DB_CREDENTIALS['mssql']['password']
+        DATABASE = DB_CREDENTIALS['mssql']['database']
+        PORT = DB_CREDENTIALS['mssql']['port']
 
         mssql_ds = MSSQLDS(
-            table='test_mindsdb',
+            query='SELECT * FROM dbo.insurance LIMIT 100',
             host=HOST,
             user=USER,
             password=PASSWORD,
@@ -36,6 +26,4 @@ class TestMSSQL(unittest.TestCase):
         )
 
         assert (len(mssql_ds.df) == 200)
-
-        mdb = Predictor(name='analyse_dataset_test_predictor', log_level=logging.ERROR)
         F.analyse_dataset(from_data=mssql_ds)

--- a/tests/integration_tests/data_sources/test_ms_sql_ds.py
+++ b/tests/integration_tests/data_sources/test_ms_sql_ds.py
@@ -17,7 +17,7 @@ class TestMSSQL(unittest.TestCase):
         PORT = DB_CREDENTIALS['mssql']['port']
 
         mssql_ds = MSSQLDS(
-            query='SELECT * FROM dbo.insurance LIMIT 100',
+            query='SELECT * FROM dbo.insurance LIMIT 233',
             host=HOST,
             user=USER,
             password=PASSWORD,
@@ -25,5 +25,5 @@ class TestMSSQL(unittest.TestCase):
             port=PORT
         )
 
-        assert (len(mssql_ds.df) == 200)
+        assert (len(mssql_ds.df) == 233)
         F.analyse_dataset(from_data=mssql_ds)

--- a/tests/integration_tests/data_sources/test_snowflake_ds.py
+++ b/tests/integration_tests/data_sources/test_snowflake_ds.py
@@ -5,6 +5,7 @@ from . import DB_CREDENTIALS, break_dataset
 
 
 class TestSnowflake(unittest.TestCase):
+    @unittest.skip('Snowflake too buggy')
     def test_snowflake_ds(self):
         if os.name == 'nt':
             print('Snowflake datasource (SnowflakeDS) can\'t be used on windows at the moment due to the connector not working')


### PR DESCRIPTION
## Why

*  #263 
* Also https://github.com/mindsdb/mindsdb/issues/1003

## How

* Added mssql instance credentials to the .json we use for testing
* Enabled mssql tests
* Fixed a few names and switched library in the MSSql datasource
* Removed old mssql tests (creating it's own data) and replaced it with a testcase that uses data from the remote mssql