### PR TITLE
turn on/off telemetry endpoint

### DIFF
--- a/mindsdb_native/__init__.py
+++ b/mindsdb_native/__init__.py
@@ -77,7 +77,7 @@ MindsDB = Predictor
 try:
     from mindsdb_native.libs.helpers.general_helpers import check_for_updates
     from mindsdb_native.config import CONFIG
-    if CONFIG.CHECK_FOR_UPDATES:
+    if CONFIG.CHECK_FOR_UPDATES and CONFIG.telemetry_enabled():
         check_for_updates()
 except Exception as e:
     print(e)

--- a/mindsdb_native/config/__init__.py
+++ b/mindsdb_native/config/__init__.py
@@ -5,6 +5,7 @@
 """
 
 
+import os.path
 import logging
 from .helpers import *
 import mindsdb_native.libs.constants.mindsdb as CONST
@@ -32,6 +33,11 @@ class Config:
 
     # Default options for unning on sagemaker
     SAGEMAKER = if_env_else('SAGEMAKER', False)
+
+    @classmethod
+    def telemetry_enabled(cls):
+        telemetry_file = os.path.join(cls.MINDSDB_STORAGE_PATH, '..', 'telemetry.lock')
+        return not os.path.exists(telemetry_file)
 
 
 CONFIG = Config()

--- a/mindsdb_native/libs/controllers/predictor.py
+++ b/mindsdb_native/libs/controllers/predictor.py
@@ -98,7 +98,7 @@ class Predictor:
         self.report_uuid = 'no_report'
         try:
             from mindsdb_native.libs.helpers.general_helpers import check_for_updates
-            if CONFIG.CHECK_FOR_UPDATES:
+            if CONFIG.CHECK_FOR_UPDATES and CONFIG.telemetry_enabled():
                 self.report_uuid = check_for_updates(run_env)
         except Exception as e:
             print(e)


### PR DESCRIPTION
Closes #993

- **What**
   - Need ability to turn telemetry (like check for updates) on/off via API
- **How**
   - Created a separate endpoint in [mindsdb](https://github.com/mindsdb/mindsdb/pull/1011)
   - Telemetry moves to disabled state when telemetry.lock file is created in storage dir. It is enabled otherwise
   - It looks a little bit strage, that needs to create smth to disable telemetry. But otherwise (when needs to create lock file on filesystem to enable it) CHECK_FOR_UPDATE=1 value doesn't make any affect by default.