### PR TITLE
added index reseting

### DIFF
--- a/mindsdb_native/libs/controllers/functional.py
+++ b/mindsdb_native/libs/controllers/functional.py
@@ -248,12 +248,14 @@ def get_model_data(model_name=None, lmd=None):
 
     amd['data_source'] = lmd['data_source_name']
 
+    amd['timeseries'] = {
+        'is_timeseries': False
+    }
     if 'tss' in lmd:
         if lmd['tss']['is_timeseries']:
             amd['timeseries'] = {}
             amd['timeseries']['user_settings'] = lmd['tss']
-        else:
-            amd['timeseries'] = None
+
 
     amd['data_analysis_v2'] = lmd.get('stats_v2',None)
     amd['setup_args'] = lmd.get('setup_args',None)

--- a/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
+++ b/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
@@ -25,7 +25,6 @@ def _ts_to_obj(df, historical_columns):
 def _ts_order_col_to_cell_lists(df, historical_columns):
     for order_col in historical_columns:
         for ii in range(len(df)):
-            # Needed because of a pandas bug that causes above to fail for small dataframes
             label = df.index.values[ii]
             df.at[label, order_col] = [df.at[label, order_col]]
     return df
@@ -288,8 +287,8 @@ class LightwoodBackend:
             lightwood.config.config.CONFIG.USE_CUDA = self.transaction.lmd['use_gpu']
 
         if self.transaction.lmd['quick_learn']:
-            self.transaction.input_data.train_df = pd.concat([copy.deepcopy(self.transaction.input_data.train_df),copy.deepcopy(self.transaction.input_data.test_df)])
-            self.transaction.input_data.test_df = copy.deepcopy(self.transaction.input_data.validation_df)
+            self.transaction.input_data.train_df = pd.concat([copy.deepcopy(self.transaction.input_data.train_df),copy.deepcopy(self.transaction.input_data.test_df)]).reset_index()
+            self.transaction.input_data.test_df = copy.deepcopy(self.transaction.input_data.validation_df).reset_index()
 
         secondary_type_dict = {}
         if self.transaction.lmd['tss']['is_timeseries']:


### PR DESCRIPTION
## Why

* Quick learn was failing when solving a group by timeseries problem

## How

* Concatenating test and train dataframes during quick_learn requires an index reset when a group by is present. I'm unsure exactly why to be honest, it has to do with the `.at` function being used, I suspects it's because the indexes between train and test are not continous when a group by is present, since data is split in an 80/10/10 way for each group by after ordering, so we might have something like:

train -> 0...16
test -> 16..18
valid -> 18..20
train -> 20..100
test -> 100..110
valid -> 110..120 

Using `.iloc` instead of `.at` would fix this, but I'm certain there were other edge cases that made `.at` favorable to `.iloc`, though I can't remember them. For one, `.at` is bound to be faster.