### PR TITLE
Fix pyathena dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 <p align="center">
    <a href="https://github.com/mindsdb/mindsdb_native/actions"><img src="https://github.com/mindsdb/mindsdb_native/workflows/MindsDB%20Native%20workflow/badge.svg" alt="MindsDB Native Workflow"></a>
   <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.6%20|%203.7|%203.8-brightgreen.svg" alt="Python supported"></a>
-   <a href="https://pypi.org/project/MindsDB/"><img src="https://badge.fury.io/py/MindsDB.svg" alt="PyPi Version"></a>
+   <a href="https://pypi.org/project/mindsdb_native/"><img src="https://badge.fury.io/py/mindsdb-native.svg" alt="PyPi Version"></a>
   <a href="https://pypi.org/project/MindsDB/"><img src="https://img.shields.io/pypi/dm/mindsdb" alt="PyPi Downloads"></a>
   <a href="https://community.mindsdb.com/"><img src="https://img.shields.io/discourse/posts?server=https%3A%2F%2Fcommunity.mindsdb.com%2F" alt="MindsDB Community"></a>
   <a href="https://www.mindsdb.com/"><img src="https://img.shields.io/website?url=https%3A%2F%2Fwww.mindsdb.com%2F" alt="MindsDB Website"></a>

--- a/assets/contributions-agreement/signatures/cla.json
+++ b/assets/contributions-agreement/signatures/cla.json
@@ -23,6 +23,14 @@
       "created_at": "2020-10-14T16:24:55Z",
       "repoId": 268208314,
       "pullRequestNo": 233
+    },
+    {
+      "name": "abitrolly",
+      "id": 8781107,
+      "comment_id": 748058002,
+      "created_at": "2020-12-18T12:24:57Z",
+      "repoId": 268208314,
+      "pullRequestNo": 364
     }
   ]
 }

--- a/mindsdb_native/libs/data_sources/aws_athena_ds.py
+++ b/mindsdb_native/libs/data_sources/aws_athena_ds.py
@@ -1,5 +1,5 @@
 from pyathena import connect
-from pyathena.util import as_pandas
+from pyathena.pandas.util import as_pandas
 
 from mindsdb_native.libs.data_types.data_source import SQLDataSource
 

--- a/mindsdb_native/libs/data_sources/aws_athena_ds.py
+++ b/mindsdb_native/libs/data_sources/aws_athena_ds.py
@@ -6,7 +6,7 @@ from mindsdb_native.libs.data_types.data_source import SQLDataSource
 
 class AthenaDS(SQLDataSource):
     def __init__(self, query, staging_dir, database=None,
-                 access_key=None, secret_key=None, region_name=None):
+                 access_key=None, secret_key=None, region_name=None, table=None):
         """
         :param query: Query to be executed. Ex. SELECT * FROM db.table;
         :param staging_dir: Full S3 path where Athena temp data will stored. Ex. s3://bucket_name/athena/staging

--- a/mindsdb_native/libs/data_sources/aws_athena_ds.py
+++ b/mindsdb_native/libs/data_sources/aws_athena_ds.py
@@ -16,7 +16,7 @@ class AthenaDS(SQLDataSource):
         :param secret_key: Secret Key used if supplied else used default credentials.
         :param region_name: Region used if supplied else used default region.
         """
-        super().__init__()
+        super().__init__(query)
 
         if (not database or not table) and not query:
             raise ValueError('Either database and table or query should be passed.')

--- a/optional_requirements_extra_data_sources.txt
+++ b/optional_requirements_extra_data_sources.txt
@@ -2,6 +2,6 @@ boto3 >= 1.9.0
 pg8000 >= 1.15.3
 python-tds >= 1.10.0
 pymongo >= 3.10.1
-PyAthena >= 1.11.2
+PyAthena >= 2.0.0
 google-cloud-storage
 google-auth


### PR DESCRIPTION
## Why
-  PyAthena 2.0.0 contains breaking change, so mindsdb_native cannot load athena_ds .
    - Error message: `Athena Datasource is not available by default. If you wish to use it, please install mindsdb_native[extra_data_sources]` 
    - [PyAthena difference](https://github.com/laughingman7743/PyAthena/compare/v1.11.2...v2.0.0#diff-ab524ae115319db0115b030d3d4aa3f01494d9ce1843ff84d6c6186495313eacL62)

## How
- Update pyathena minimum version to 2.0.0
- Update as_pandas import path
