### PR TITLE
add disable_column_importance flag

### DIFF
--- a/mindsdb_native/libs/controllers/predictor.py
+++ b/mindsdb_native/libs/controllers/predictor.py
@@ -263,7 +263,8 @@ class Predictor:
                 allow_incomplete_history = advanced_args.get('allow_incomplete_history', False),
                 quick_learn = advanced_args.get('quick_learn', None),
                 quick_predict = advanced_args.get('quick_predict', False),
-                apply_to_columns = advanced_args.get('apply_to_columns', {})
+                apply_to_columns = advanced_args.get('apply_to_columns', {}),
+                disable_column_importance = advanced_args.get('disable_column_importance', {})
             )
 
             if rebuild_model is False:

--- a/mindsdb_native/libs/controllers/predictor.py
+++ b/mindsdb_native/libs/controllers/predictor.py
@@ -264,7 +264,7 @@ class Predictor:
                 quick_learn = advanced_args.get('quick_learn', None),
                 quick_predict = advanced_args.get('quick_predict', False),
                 apply_to_columns = advanced_args.get('apply_to_columns', {}),
-                disable_column_importance = advanced_args.get('disable_column_importance', {})
+                disable_column_importance = advanced_args.get('disable_column_importance', False)
             )
 
             if rebuild_model is False:


### PR DESCRIPTION
Closes https://github.com/mindsdb/mindsdb_native/issues/361

Added `disable_column_importance` flag to advanced arguments.
When it's set to `True`, column importances are not computed.