### PR TITLE
Never ignore group_by columns

### DIFF
--- a/mindsdb_native/libs/phases/type_deductor/type_deductor.py
+++ b/mindsdb_native/libs/phases/type_deductor/type_deductor.py
@@ -334,7 +334,8 @@ class TypeDeductor(BaseModule):
                     if col_name not in self.transaction.lmd['predict_columns']:
                         if (self.transaction.lmd.get('tss', None) and
                                 self.transaction.lmd['tss']['is_timeseries'] and
-                                col_name in self.transaction.lmd['tss']['order_by']):
+                                col_name in self.transaction.lmd['tss']['order_by'] and
+                                col_name in self.transaction.lmd['tss']['group_by']):
                             pass
                         else:
                             self.transaction.lmd['columns_to_ignore'].append(col_name)

--- a/mindsdb_native/libs/phases/type_deductor/type_deductor.py
+++ b/mindsdb_native/libs/phases/type_deductor/type_deductor.py
@@ -335,7 +335,7 @@ class TypeDeductor(BaseModule):
                         if (self.transaction.lmd.get('tss', None) and
                                 self.transaction.lmd['tss']['is_timeseries'] and
                                 col_name in self.transaction.lmd['tss']['order_by'] and
-                                col_name in self.transaction.lmd['tss']['group_by']):
+                                col_name in (self.transaction.lmd['tss']['group_by'] or [])):
                             pass
                         else:
                             self.transaction.lmd['columns_to_ignore'].append(col_name)

--- a/mindsdb_native/libs/phases/type_deductor/type_deductor.py
+++ b/mindsdb_native/libs/phases/type_deductor/type_deductor.py
@@ -334,8 +334,8 @@ class TypeDeductor(BaseModule):
                     if col_name not in self.transaction.lmd['predict_columns']:
                         if (self.transaction.lmd.get('tss', None) and
                                 self.transaction.lmd['tss']['is_timeseries'] and
-                                col_name in self.transaction.lmd['tss']['order_by'] and
-                                col_name in (self.transaction.lmd['tss']['group_by'] or [])):
+                                (col_name in self.transaction.lmd['tss']['order_by'] or
+                                col_name in (self.transaction.lmd['tss']['group_by'] or []))):
                             pass
                         else:
                             self.transaction.lmd['columns_to_ignore'].append(col_name)


### PR DESCRIPTION
Closes https://github.com/mindsdb/mindsdb_native/issues/355

- `group_by` columns are not ignored if they're also a unique identifier.

Historical columns can't be ignored because they're added to the dataframe in the `ModelInterface` phase, so no changes for that in this PR.