### PR TITLE
Improve MongoDS

### DIFF
--- a/mindsdb_native/libs/data_sources/mongodb_ds.py
+++ b/mindsdb_native/libs/data_sources/mongodb_ds.py
@@ -1,3 +1,5 @@
+import re
+
 import pandas as pd
 from pymongo import MongoClient
 
@@ -5,7 +7,7 @@ from mindsdb_native.libs.data_types.data_source import DataSource
 
 class MongoDS(DataSource):
     def __init__(self, query, collection, database='database',
-                 host='localhost', port=27017, user='admin', password='123'):
+                 host='127.0.0.1', port=None, user=None, password=None):
         super().__init__()
 
         if not isinstance(query, dict):
@@ -13,10 +15,13 @@ class MongoDS(DataSource):
         else:
             self._query = query
 
+        if not re.match(r'^mongodb(\+srv)?:\/\/', host.lower()):
+            port = int(port or 27017)
+
         self.collection = collection
         self.database = database
         self.host = host
-        self.port = int(port)
+        self.port = port
         self.user = user
         self.password = password
 


### PR DESCRIPTION
**Why**

We need support 'connection string' for mongods. That only way for connection to replica set or mongo cloud.  Port, user and password can be specified in connection string, so default values in MongoDS lead to error in that case.

**How**

Removed default values, added check 'is connection string' to set default port. 