### PR TITLE
Add 'historical' flag to historical columns

### DIFF
--- a/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
+++ b/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
@@ -86,7 +86,9 @@ class ModelAnalyzer(BaseModule):
         empty_input_predictions_test = {}
 
         ignorable_input_columns = [x for x in input_columns if self.transaction.lmd['stats_v2'][x]['typing']['data_type'] != DATA_TYPES.FILE_PATH
-                           and (not self.transaction.lmd['tss']['is_timeseries'] or x not in self.transaction.lmd['tss']['order_by'])]
+                                   and (not self.transaction.lmd['tss']['is_timeseries'] or
+                                        (x not in self.transaction.lmd['tss']['order_by'] and
+                                         x not in self.transaction.lmd['tss']['historical_columns']))]
 
         for col in ignorable_input_columns:
             empty_input_predictions[col] = self.transaction.model_backend.predict('validate', ignore_columns=[col])

--- a/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
+++ b/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
@@ -217,7 +217,6 @@ class LightwoodBackend:
             if data_subtype == DATA_SUBTYPES.SHORT:
                 col_config['encoder_class'] = lightwood.encoders.text.short.ShortTextEncoder
 
-
             if col_name in self.transaction.lmd['weight_map']:
                 col_config['weights'] = self.transaction.lmd['weight_map'][col_name]
 
@@ -229,7 +228,8 @@ class LightwoodBackend:
             if col_name in self.transaction.lmd['predict_columns']:
                 if self.transaction.lmd['tss']['is_timeseries']:
                     col_config['additional_info'] = {
-                        'nr_predictions': self.transaction.lmd['tss']['nr_predictions']
+                        'nr_predictions': self.transaction.lmd['tss']['nr_predictions'],
+                        'historical': False
                     }
                 config['output_features'].append(col_config)
 
@@ -237,6 +237,7 @@ class LightwoodBackend:
                     p_col_config = copy.deepcopy(col_config)
                     p_col_config['name'] = f"__mdb_ts_previous_{p_col_config['name']}"
                     p_col_config['original_type'] = col_config['type']
+                    p_col_config['previous'] = True
                     p_col_config['type'] = ColumnDataTypes.TIME_SERIES
 
                     if 'secondary_type' in col_config:
@@ -252,9 +253,11 @@ class LightwoodBackend:
                         additional_target_config['name'] = f'{col_name}_timestep_{timestep_index}'
                         config['output_features'].append(additional_target_config)
             else:
-                if self.transaction.lmd['tss']['historical_columns']:
+                if col_name in self.transaction.lmd['tss']['historical_columns']:
                     if 'secondary_type' in col_config:
                         col_config['secondary_type'] = col_config['secondary_type']
+                    col_config['historical'] = True
+                    col_config['original_type'] = col_config['type']
                     col_config['type'] = ColumnDataTypes.TIME_SERIES
 
                 config['input_features'].append(col_config)

--- a/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
+++ b/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
@@ -20,7 +20,7 @@ def _make_pred(row):
 def _ts_to_obj(df, historical_columns):
     for hist_col in historical_columns:
         df.loc[:, hist_col] = df[hist_col].astype(object)
-        return df
+    return df
 
 def _ts_order_col_to_cell_lists(df, historical_columns):
     for order_col in historical_columns:


### PR DESCRIPTION
## Why
To enable multiple historical dependencies in Lightwood's time series encoders. For more details, see [L#349](https://github.com/mindsdb/lightwood/pull/349/) (note: this is staying as a draft until the linked PR is merged into staging, at which point I'll add a test as well).

## How
Simple PR that adds the corresponding info in the respective column configurations.

Additionally, a bug is fixed in `_ts_to_obj` to support more than one historical column.