### PR TITLE
Accuracy using ICP confidence range for numerical tasks 

### DIFF
--- a/mindsdb_native/libs/controllers/functional.py
+++ b/mindsdb_native/libs/controllers/functional.py
@@ -241,6 +241,7 @@ def get_model_data(model_name=None, lmd=None):
         pass
     elif model_name is not None:
         with MDBLock('shared', 'get_data_' + model_name):
+            print(CONFIG.MINDSDB_STORAGE_PATH, model_name, 'light_model_metadata.pickle')
             lmd = load_lmd(os.path.join(CONFIG.MINDSDB_STORAGE_PATH, model_name, 'light_model_metadata.pickle'))
 
     # ADAPTOR CODE

--- a/mindsdb_native/libs/controllers/functional.py
+++ b/mindsdb_native/libs/controllers/functional.py
@@ -241,7 +241,6 @@ def get_model_data(model_name=None, lmd=None):
         pass
     elif model_name is not None:
         with MDBLock('shared', 'get_data_' + model_name):
-            print(CONFIG.MINDSDB_STORAGE_PATH, model_name, 'light_model_metadata.pickle')
             lmd = load_lmd(os.path.join(CONFIG.MINDSDB_STORAGE_PATH, model_name, 'light_model_metadata.pickle'))
 
     # ADAPTOR CODE

--- a/mindsdb_native/libs/controllers/predictor.py
+++ b/mindsdb_native/libs/controllers/predictor.py
@@ -246,7 +246,7 @@ class Predictor:
                 force_disable_cache = advanced_args.get('force_disable_cache', disable_lightwood_transform_cache),
                 force_categorical_encoding = advanced_args.get('force_categorical_encoding', []),
                 force_column_usage = advanced_args.get('force_column_usage', []),
-                output_class_distribution = advanced_args.get('output_class_distribution', False),
+                output_class_distribution = advanced_args.get('output_class_distribution', True),
                 use_selfaware_model = advanced_args.get('use_selfaware_model', True),
                 deduplicate_data = advanced_args.get('deduplicate_data', True),
                 null_values = advanced_args.get('null_values', {}),

--- a/mindsdb_native/libs/controllers/transaction.py
+++ b/mindsdb_native/libs/controllers/transaction.py
@@ -361,7 +361,7 @@ class PredictTransaction(Transaction):
             icp_X = deepcopy(predictions_df)
 
             if self.lmd['tss']['is_timeseries']:
-                icp_X, _, _, _ = self.model_backend._ts_reshape(icp_X)
+                icp_X, _, _, _ = self.model_backend._ts_reshape(icp_X)  # TODO: avoid inefficient reshaping
 
             for col in self.lmd['columns_to_ignore'] + self.lmd['predict_columns']:
                 if col in icp_X.columns:

--- a/mindsdb_native/libs/controllers/transaction.py
+++ b/mindsdb_native/libs/controllers/transaction.py
@@ -381,7 +381,7 @@ class PredictTransaction(Transaction):
                     if typing_info['data_type'] == DATA_TYPES.NUMERIC or \
                             (typing_info['data_type'] == DATA_TYPES.SEQUENTIAL and
                                 DATA_TYPES.NUMERIC in typing_info['data_type_dist'].keys()):
-                        std_tol = 2  # std devs
+                        std_tol = 1.25  # std devs
                         spread_tol = 0.2
                         bins = self.lmd['stats_v2'][predicted_col]['histogram']['x']
                         tolerance = min(self.lmd['stats_v2']['train_std_dev'][predicted_col] * std_tol,

--- a/mindsdb_native/libs/controllers/transaction.py
+++ b/mindsdb_native/libs/controllers/transaction.py
@@ -381,13 +381,11 @@ class PredictTransaction(Transaction):
                     if typing_info['data_type'] == DATA_TYPES.NUMERIC or \
                             (typing_info['data_type'] == DATA_TYPES.SEQUENTIAL and
                                 DATA_TYPES.NUMERIC in typing_info['data_type_dist'].keys()):
-                        tol_const = 2  # std devs
-                        # tolerance = self.lmd['stats_v2']['train_std_dev'][predicted_col] * tol_const
+                        std_tol = 2  # std devs
+                        spread_tol = 0.2
                         bins = self.lmd['stats_v2'][predicted_col]['histogram']['x']
-                        diffs = []
-                        for a, b in zip(*[iter(bins)] * 2):
-                            diffs.append(abs(a - b))
-                        tolerance = (sum(diffs) / len(diffs)) * tol_const
+                        tolerance = min(self.lmd['stats_v2']['train_std_dev'][predicted_col] * std_tol,
+                                        (bins[-1] - bins[0]) * spread_tol)
 
                         self.lmd['all_conformal_ranges'][predicted_col] = self.hmd['icp'][predicted_col].predict(X.values)
 

--- a/mindsdb_native/libs/controllers/transaction.py
+++ b/mindsdb_native/libs/controllers/transaction.py
@@ -392,6 +392,7 @@ class PredictTransaction(Transaction):
                                 DATA_TYPES.NUMERIC in typing_info['data_type_dist'].keys()):
                         std_tol = 0.5
                         tolerance = self.lmd['stats_v2']['train_std_dev'][predicted_col] * std_tol
+                        self.hmd['icp'][predicted_col].nc_function.model.prediction_cache = output_data[predicted_col]
                         self.lmd['all_conformal_ranges'][predicted_col] = self.hmd['icp'][predicted_col].predict(X.values)
 
                         for sample_idx in range(self.lmd['all_conformal_ranges'][predicted_col].shape[0]):
@@ -419,6 +420,7 @@ class PredictTransaction(Transaction):
                                 DATA_TYPES.CATEGORICAL in typing_info['data_type_dist'].keys()):
                         if self.lmd['stats_v2'][predicted_col]['typing']['data_subtype'] != DATA_SUBTYPES.TAGS:
                             significances = list(range(20)) + list(range(20, 100, 10))  # max permitted error rate
+                            self.hmd['icp'][predicted_col].nc_function.model.prediction_cache = output_data[f'{predicted_col}_class_distribution']
                             all_ranges = np.array(
                                 [self.hmd['icp'][predicted_col].predict(X.values, significance=s / 100)
                                     for s in significances])

--- a/mindsdb_native/libs/controllers/transaction.py
+++ b/mindsdb_native/libs/controllers/transaction.py
@@ -381,12 +381,8 @@ class PredictTransaction(Transaction):
                     if typing_info['data_type'] == DATA_TYPES.NUMERIC or \
                             (typing_info['data_type'] == DATA_TYPES.SEQUENTIAL and
                                 DATA_TYPES.NUMERIC in typing_info['data_type_dist'].keys()):
-                        std_tol = 1.25  # std devs
-                        spread_tol = 0.2
-                        bins = self.lmd['stats_v2'][predicted_col]['histogram']['x']
-                        tolerance = min(self.lmd['stats_v2']['train_std_dev'][predicted_col] * std_tol,
-                                        (bins[-1] - bins[0]) * spread_tol)
-
+                        std_tol = 0.5
+                        tolerance = self.lmd['stats_v2']['train_std_dev'][predicted_col] * std_tol
                         self.lmd['all_conformal_ranges'][predicted_col] = self.hmd['icp'][predicted_col].predict(X.values)
 
                         for sample_idx in range(self.lmd['all_conformal_ranges'][predicted_col].shape[0]):

--- a/mindsdb_native/libs/controllers/transaction.py
+++ b/mindsdb_native/libs/controllers/transaction.py
@@ -381,8 +381,13 @@ class PredictTransaction(Transaction):
                     if typing_info['data_type'] == DATA_TYPES.NUMERIC or \
                             (typing_info['data_type'] == DATA_TYPES.SEQUENTIAL and
                                 DATA_TYPES.NUMERIC in typing_info['data_type_dist'].keys()):
-                        tol_const = 1  # std devs
-                        tolerance = self.lmd['stats_v2']['train_std_dev'][predicted_col] * tol_const
+                        tol_const = 2  # std devs
+                        # tolerance = self.lmd['stats_v2']['train_std_dev'][predicted_col] * tol_const
+                        bins = self.lmd['stats_v2'][predicted_col]['histogram']['x']
+                        diffs = []
+                        for a, b in zip(*[iter(bins)] * 2):
+                            diffs.append(abs(a - b))
+                        tolerance = (sum(diffs) / len(diffs)) * tol_const
 
                         self.lmd['all_conformal_ranges'][predicted_col] = self.hmd['icp'][predicted_col].predict(X.values)
 

--- a/mindsdb_native/libs/helpers/conformal_helpers.py
+++ b/mindsdb_native/libs/helpers/conformal_helpers.py
@@ -74,7 +74,7 @@ def get_conf_range(X, icp, target, typing_info, lmd, std_tol=1):
         return conf, pvals
 
     # default
-    return 0.005, np.zeros_like((X.size, 2))
+    return 0.005, np.zeros_like((X.size, 2)).reshape(1, -1)
 
 
 class BoostedSignErrorErrFunc(RegressionErrFunc):
@@ -90,7 +90,7 @@ class BoostedSignErrorErrFunc(RegressionErrFunc):
 
     def apply_inverse(self, nc, significance):
         nc = np.sort(nc)[::-1]
-        if nc.size < 100:
+        if 1 < nc.size < 100:
             x = np.arange(nc.shape[0])
             interp = interp1d(x, nc)
             nc = interp(np.linspace(0, nc.size-1, 100))

--- a/mindsdb_native/libs/helpers/general_helpers.py
+++ b/mindsdb_native/libs/helpers/general_helpers.py
@@ -196,8 +196,14 @@ def evaluate_regression_accuracy(
         backend,
         **kwargs
     ):
-    r2 = r2_score(true_values, predictions[column])
-    return max(r2, 0)
+    if f'{column}_confidence_range' in predictions:
+        Y = np.array(true_values)
+        ranges = predictions[f'{column}_confidence_range']
+        within = ((Y >= ranges[:, 0]) & (Y <= ranges[:, 1]))
+        return sum(within)/len(within)
+    else:
+        r2 = r2_score(true_values, predictions[column])
+        return max(r2, 0)
 
 
 def evaluate_classification_accuracy(column, predictions, true_values, **kwargs):

--- a/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
+++ b/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
@@ -42,7 +42,6 @@ class ModelAnalyzer(BaseModule):
         self.transaction.lmd['test_data_plot'] = {}
 
         # conformal prediction confidence estimation
-        # TODO: implement prediction cache for speedup
         self.transaction.lmd['stats_v2']['train_std_dev'] = {}
         self.transaction.hmd['label_encoders'] = {}
         self.transaction.hmd['icp'] = {'active': False}

--- a/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
+++ b/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
@@ -4,6 +4,7 @@ from mindsdb_native.libs.phases.base_module import BaseModule
 from mindsdb_native.libs.helpers.general_helpers import evaluate_accuracy
 from mindsdb_native.libs.helpers.conformal_helpers import ConformalClassifierAdapter, ConformalRegressorAdapter
 from mindsdb_native.libs.helpers.conformal_helpers import SelfawareNormalizer, clean_df, get_significance_level
+from mindsdb_native.libs.helpers.conformal_helpers import BoostedSignErrorErrFunc
 from mindsdb_native.libs.helpers.accuracy_stats import AccStats
 from mindsdb_native.libs.data_types.mindsdb_logger import log
 from sklearn.metrics import balanced_accuracy_score, r2_score
@@ -83,7 +84,7 @@ class ModelAnalyzer(BaseModule):
 
             else:
                 adapter = ConformalRegressorAdapter
-                nc_function = SignErrorErrFunc()
+                nc_function = BoostedSignErrorErrFunc()
                 nc_class = RegressorNc
                 icp_class = IcpRegressor
 
@@ -148,10 +149,10 @@ class ModelAnalyzer(BaseModule):
                     if split == 'cal':
                         # calibrate conformal estimator with validation dataset
                         self.transaction.hmd['icp'][target].calibrate(X.values, y)
+                    # TODO: cover categorical case here and guard min val size
                     elif split == 'test':
                         conf = get_significance_level(X, y, icp, target, typing_info, self.transaction.lmd)
                     else:
-                        # TODO: cover categorical case here
                         ranges = self.transaction.hmd['icp'][target].predict(X.values)[:, :, int(100*(0.99-conf))]
                         normal_predictions[f'{target}_confidence_range'] = ranges
 

--- a/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
+++ b/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
@@ -57,10 +57,9 @@ class ModelAnalyzer(BaseModule):
                                  DATA_TYPES.CATEGORICAL in typing_info['data_type_dist'].keys())
 
             fit_params = {
-                'columns_to_ignore': [],
+                'columns_to_ignore': self.transaction.lmd['columns_to_ignore'],
                 'nr_preds': self.transaction.lmd['tss'].get('nr_predictions', 0)
             }
-            fit_params['columns_to_ignore'].extend(self.transaction.lmd['columns_to_ignore'])
             fit_params['columns_to_ignore'].extend([col for col in output_columns if col != target])
             fit_params['columns_to_ignore'].extend([f'{target}_timestep_{i}' for i in range(1, fit_params['nr_preds'])])
 
@@ -95,12 +94,11 @@ class ModelAnalyzer(BaseModule):
                     normalizer = None
 
                 nc = nc_class(model, nc_function, normalizer=normalizer)
-
                 icp = icp_class(nc)
+
                 if is_classification:
                     icp.nc_function.model.prediction_cache = np.array(normal_predictions[f'{target}_class_distribution'])
-                    # TODO: expose from lightwood and use here
-                    # {i:cls for i, cls in enumerate(self.transaction.lmd['weight_map'].keys())}
+                    # TODO: expose directly from lightwood and use here, instead of the inferred order
                     icp.nc_function.model.class_map = [i for i in self.transaction.lmd['weight_map'].keys()]
                 else:
                     icp.nc_function.model.prediction_cache = np.array(normal_predictions[target])

--- a/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
+++ b/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
@@ -14,7 +14,7 @@ from copy import deepcopy
 from sklearn.preprocessing import OneHotEncoder
 from lightwood.mixers.nn import NnMixer
 from nonconformist.icp import IcpRegressor, IcpClassifier
-from nonconformist.nc import RegressorNc, AbsErrorErrFunc, ClassifierNc, InverseProbabilityErrFunc
+from nonconformist.nc import RegressorNc, SignErrorErrFunc, ClassifierNc, InverseProbabilityErrFunc
 
 
 class ModelAnalyzer(BaseModule):
@@ -230,7 +230,7 @@ class ModelAnalyzer(BaseModule):
 
             else:
                 adapter = ConformalRegressorAdapter
-                nc_function = AbsErrorErrFunc()
+                nc_function = SignErrorErrFunc()
                 nc_class = RegressorNc
                 icp_class = IcpRegressor
 

--- a/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
+++ b/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
@@ -549,8 +549,11 @@ class LightwoodBackend:
 
                 formated_predictions[k] = predictions[k]['predictions']
                 if self.transaction.lmd['output_class_distribution']:
-                    formated_predictions[f'{k}_class_distribution'] = predictions[k]['class_distribution']
-                    self.transaction.lmd['stats_v2'][k]['lightwood_class_map'] = predictions[k]['class_labels']
+                    try:
+                        formated_predictions[f'{k}_class_distribution'] = predictions[k]['class_distribution']
+                        self.transaction.lmd['stats_v2'][k]['lightwood_class_map'] = predictions[k]['class_labels']
+                    except KeyError:
+                        pass
 
                 if self.nr_predictions > 1:
                     formated_predictions[k] = [[x] for x in formated_predictions[k]]

--- a/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
+++ b/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
@@ -537,7 +537,7 @@ class LightwoodBackend:
             if self.transaction.lmd['quick_predict']:
                 for k in predictions:
                     formated_predictions[k] = predictions[k]['predictions']
-                    if self.transaction.lmd['output_class_distribution']:
+                    if self.transaction.lmd['output_class_distribution'] and predictions[k].get('class_distribution', False):
                         formated_predictions[f'{k}_class_distribution'] = predictions[k]['class_distribution']
                         self.transaction.lmd['stats_v2'][k]['lightwood_class_map'] = predictions[k]['class_labels']
                     formated_predictions_arr.append(formated_predictions)

--- a/tests/unit_tests/libs/helpers/test_conformal.py
+++ b/tests/unit_tests/libs/helpers/test_conformal.py
@@ -30,7 +30,7 @@ class TestConformal(unittest.TestCase):
         target = 'medv'
 
         x_tr = self._df_from_xy(X_train, Y_train, target)
-        p = Predictor('ConformalTest')
+        p = Predictor('test_conformal')
         p.learn(
             from_data=x_tr,
             to_predict=target,
@@ -64,7 +64,7 @@ class TestConformal(unittest.TestCase):
             tr[target] = tr[target].astype(label_type)
             te[target] = te[target].astype(label_type)
 
-            p = Predictor(f'ConformalTest_{type_name}')
+            p = Predictor(f'test_conformal_{type_name}')
             p.learn(
                 from_data=tr,
                 to_predict=target,


### PR DESCRIPTION
## Why
Currently, the reported final score for a predictor with a numerical target is R2 score, which is not easy to understand by non-technical users. Accuracy score, as defined by a true value falling within the predicted confidence range, is easier to understand and should be once again used as the reported metric for numerical targets.

## How
This PR changes the order of steps in the model analysis phase. Now, the conformal predictor is fitted at the start, and a newly added procedure determines an overall confidence level as well as the confidence ranges for the validation dataset samples, which is then used to calculate an accuracy score.

Additionally, a custom nonconformity function linearly interpolates the scores whenever our validation dataset is smaller than 100 samples, helping alleviate suboptimal confidence range generation in these cases.

Also, the criterion for confidence range width at query time has been made stricter, so that bounds are smaller and more informative, although at the cost of reduced confidence. There are some options to improve this trade-off, like a better normalizer policy, or [Conformalized Quantile Regression](http://papers.neurips.cc/paper/8613-conformalized-quantile-regression.pdf), but these require further research.

## Note
~~This PR will stay as a draft until next week, pending coordination with frontend team.~~
This indirectly addresses #383, because all calls have been removed.