### PR TITLE
Some fixes for quick predict 

### DIFF
--- a/mindsdb_native/libs/controllers/predictor.py
+++ b/mindsdb_native/libs/controllers/predictor.py
@@ -359,7 +359,7 @@ class Predictor:
         advanced_args['quick_predict'] = True
         advanced_args['return_raw_predictions'] = True
 
-        return self.predict(when_data, use_gpu, advanced_args, backend)
+        return self.predict(when_data, use_gpu=use_gpu, advanced_args=advanced_args, backend=backend)
 
     def predict(self,
                 when_data,

--- a/mindsdb_native/libs/controllers/transaction.py
+++ b/mindsdb_native/libs/controllers/transaction.py
@@ -325,7 +325,11 @@ class PredictTransaction(Transaction):
         self._call_phase_module(module_name='ModelInterface', mode='predict')
 
         if self.lmd['return_raw_predictions']:
-            return self.hmd['predictions']
+            self.output_data = PredictTransactionOutputData(
+                transaction=self,
+                data=self.hmd['predictions']
+            )
+            return self.output_data
 
         output_data = {col: [] for col in self.lmd['columns']}
 

--- a/mindsdb_native/libs/data_types/transaction_output_row.py
+++ b/mindsdb_native/libs/data_types/transaction_output_row.py
@@ -45,7 +45,7 @@ class TransactionOutputRow:
             else:
                 answers[pred_col]['predicted_value'] = prediction_row[pred_col]
 
-            if prediction_row[f'{pred_col}_confidence'] is not None:
+            if prediction_row.get(f'{pred_col}_confidence') is not None:
                 answers[pred_col]['confidence'] = round(prediction_row[f'{pred_col}_confidence'], 4)
                 quality = 'very confident'
                 if answers[pred_col]['confidence'] < 0.8:

--- a/tests/integration_tests/flows/quick_interface.py
+++ b/tests/integration_tests/flows/quick_interface.py
@@ -27,8 +27,8 @@ class TestQuickInterface(unittest.TestCase):
         assert test_predictor.report_uuid == 'no_report'
 
         # Make some predictions with quick_predict and make sure they look alright
-        predictions = test_predictor.predict(df_test)
-        assert len(predictions['hours-per-week']) == len(df_test)
+        predictions = test_predictor.quick_predict(df_test)
+        assert len(predictions._data['hours-per-week']) == len(df_test)
         for pred in predictions['hours-per-week']:
             assert isinstance(pred,int)
             assert pred > 0

--- a/tests/integration_tests/flows/quick_interface.py
+++ b/tests/integration_tests/flows/quick_interface.py
@@ -29,8 +29,8 @@ class TestQuickInterface(unittest.TestCase):
         # Make some predictions with quick_predict and make sure they look alright
         predictions = test_predictor.quick_predict(df_test)
         assert len(predictions._data['hours-per-week']) == len(df_test)
-        for pred in predictions['hours-per-week']:
-            assert isinstance(pred,int)
+        for pred in predictions._data['hours-per-week']:
+            assert isinstance(pred, int)
             assert pred > 0
 
     def test_quick_predict_output(self):


### PR DESCRIPTION
## Why
There were some issues when using `quick_predict` after `quick_learn`ing with a predictor.

## How
Adding explicit keyword argument passing, setting the `output_data` in the predict transaction, modifying `explain` to handle absence of confidence range info, and calling `quick_predict` in the `quick_interface` flow test. 