### PR TITLE
Remove multiprocess usage for small timeseries dataframes

### DIFF
--- a/mindsdb_native/libs/controllers/transaction.py
+++ b/mindsdb_native/libs/controllers/transaction.py
@@ -427,8 +427,8 @@ class PredictTransaction(Transaction):
                                     output_data[f'{predicted_col}_confidence'][sample_idx] = 0.005
         else:
             for predicted_col in self.lmd['predict_columns']:
-                output_data[f'{predicted_col}_confidence'] = None
-                output_data[f'{predicted_col}_confidence_range'] = None
+                output_data[f'{predicted_col}_confidence'] = [None] * len(output_data[predicted_col])
+                output_data[f'{predicted_col}_confidence_range'] = [[None, None]] * len(output_data[predicted_col])
 
         self.output_data = PredictTransactionOutputData(
             transaction=self,

--- a/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
+++ b/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
@@ -128,12 +128,21 @@ class LightwoodBackend:
 
         pool = mp.Pool(processes = (mp.cpu_count() - 1))
 
-        # Make type `object` so that dataframe cells can be python lists
-        df_arr = pool.map(partial(_ts_to_obj, historical_columns=ob_arr + self.transaction.lmd['tss']['historical_columns']), df_arr)
-        df_arr = pool.map(partial(_ts_order_col_to_cell_lists, historical_columns=ob_arr + self.transaction.lmd['tss']['historical_columns']), df_arr)
-        df_arr = pool.map(partial(_ts_add_previous_rows, historical_columns=ob_arr + self.transaction.lmd['tss']['historical_columns'], window=window), df_arr)
-        if self.transaction.lmd['tss']['use_previous_target']:
-            df_arr = pool.map(partial(_ts_add_previous_target, predict_columns=self.transaction.lmd['predict_columns'], nr_predictions=self.nr_predictions, window=window), df_arr)
+        if len(original_df) > 500:
+            # Make type `object` so that dataframe cells can be python lists
+            df_arr = pool.map(partial(_ts_to_obj, historical_columns=ob_arr + self.transaction.lmd['tss']['historical_columns']), df_arr)
+            df_arr = pool.map(partial(_ts_order_col_to_cell_lists, historical_columns=ob_arr + self.transaction.lmd['tss']['historical_columns']), df_arr)
+            df_arr = pool.map(partial(_ts_add_previous_rows, historical_columns=ob_arr + self.transaction.lmd['tss']['historical_columns'], window=window), df_arr)
+            if self.transaction.lmd['tss']['use_previous_target']:
+                df_arr = pool.map(partial(_ts_add_previous_target, predict_columns=self.transaction.lmd['predict_columns'], nr_predictions=self.nr_predictions, window=window), df_arr)
+        else:
+            for i in range(len(df_arr)):
+                df_arr[i] = _ts_to_obj(df_arr[i], historical_columns=ob_arr + self.transaction.lmd['tss']['historical_columns'])
+                df_arr[i] = _ts_order_col_to_cell_lists(df_arr[i], historical_columns=ob_arr + self.transaction.lmd['tss']['historical_columns'])
+                df_arr[i] = _ts_add_previous_rows(df_arr[i], historical_columns=ob_arr + self.transaction.lmd['tss']['historical_columns'], window=window)
+                if self.transaction.lmd['tss']['use_previous_target']:
+                    df_arr[i] = _ts_add_previous_target(df_arr[i], predict_columns=self.transaction.lmd['predict_columns'], nr_predictions=self.nr_predictions, window=window)
+
 
         combined_df = pd.concat(df_arr)
 


### PR DESCRIPTION
## Why

* Multiprocessing was used to transform any timeseries dataframe, including those consisting of a singular rows, this added some slight overhead in case like single-valued predictions or small batch predictions, but this was negligible
* However, when the mindsdb_native predict/learn methods are called inside certain types of python processes, such as `spawn`ed processes (like those used by mindsdb to run it's APIs, due to corss-platform compatibility requirements) the multiprocess module has a quirk in it's behavior, in that it would lead to the whole of mindsdb_native being re-imported. This caused issues both because of memory consumption (each process would occupy 2.5GB+ by virtue of re-importing every single mindsdb_native dependency, rather than just those required to run it's respective function) and in terms of time (importing mindsdb_native takes ~3 seconds)

## How

* Timeseries transformations for dataframes with < 500 rows will now be done in the main python process, without the use of multiprocessing.