### PR TITLE
Output class distribution flag

### DIFF
--- a/mindsdb_native/libs/controllers/predictor.py
+++ b/mindsdb_native/libs/controllers/predictor.py
@@ -251,6 +251,7 @@ class Predictor:
                 force_disable_cache = advanced_args.get('force_disable_cache', disable_lightwood_transform_cache),
                 force_categorical_encoding = advanced_args.get('force_categorical_encoding', []),
                 force_column_usage = advanced_args.get('force_column_usage', []),
+                output_class_distribution = advanced_args.get('output_class_distribution', False),
                 use_selfaware_model = advanced_args.get('use_selfaware_model', True),
                 deduplicate_data = advanced_args.get('deduplicate_data', True),
                 null_values = advanced_args.get('null_values', {}),

--- a/mindsdb_native/libs/controllers/transaction.py
+++ b/mindsdb_native/libs/controllers/transaction.py
@@ -343,10 +343,10 @@ class PredictTransaction(Transaction):
             if column in self.lmd['predict_columns']:
                 output_data[f'__observed_{column}'] = list(predictions_df[column])
                 output_data[column] = self.hmd['predictions'][column]
-                if self.lmd['output_class_distribution']:
-                    for k in ['class_distribution', 'class_map']:
-                        field = f'{column}_{k}'
-                        output_data[field] = self.hmd['predictions'][field]
+
+                for k in ['class_distribution', 'class_map']:
+                    if f'{column}_{k}' in self.hmd['predictions']:
+                        output_data[f'{column}_{k}'] = self.hmd['predictions'][f'{column}_{k}']
             else:
                 output_data[column] = list(predictions_df[column])
 

--- a/mindsdb_native/libs/controllers/transaction.py
+++ b/mindsdb_native/libs/controllers/transaction.py
@@ -343,6 +343,10 @@ class PredictTransaction(Transaction):
             if column in self.lmd['predict_columns']:
                 output_data[f'__observed_{column}'] = list(predictions_df[column])
                 output_data[column] = self.hmd['predictions'][column]
+                if self.lmd['output_class_distribution']:
+                    for k in ['class_distribution', 'class_map']:
+                        field = f'{column}_{k}'
+                        output_data[field] = self.hmd['predictions'][field]
             else:
                 output_data[column] = list(predictions_df[column])
 

--- a/mindsdb_native/libs/controllers/transaction.py
+++ b/mindsdb_native/libs/controllers/transaction.py
@@ -343,16 +343,16 @@ class PredictTransaction(Transaction):
         else:
             predictions_df = self.input_data.data_frame
 
-        for column in self.input_data.columns:
-            if column in self.lmd['predict_columns']:
-                output_data[f'__observed_{column}'] = list(predictions_df[column])
-                output_data[column] = self.hmd['predictions'][column]
+        for col in self.input_data.columns:
+            if col in self.lmd['predict_columns']:
+                output_data[f'__observed_{col}'] = list(predictions_df[col])
+                output_data[col] = self.hmd['predictions'][col]
 
-                for k in ['class_distribution', 'class_map']:
-                    if f'{column}_{k}' in self.hmd['predictions']:
-                        output_data[f'{column}_{k}'] = self.hmd['predictions'][f'{column}_{k}']
+                if f'{col}_class_distribution' in self.hmd['predictions']:
+                    output_data[f'{col}_class_distribution'] = self.hmd['predictions'][f'{col}_class_distribution']
+                    self.lmd['lightwood_data'][f'{col}_class_map'] = self.lmd['stats_v2'][col]['lightwood_class_map']
             else:
-                output_data[column] = list(predictions_df[column])
+                output_data[col] = list(predictions_df[col])
 
         # confidence estimation
         if self.hmd['icp']['active'] and not self.lmd['quick_predict']:

--- a/mindsdb_native/libs/data_types/transaction_output_row.py
+++ b/mindsdb_native/libs/data_types/transaction_output_row.py
@@ -36,7 +36,8 @@ class TransactionOutputRow:
         answers = {}
         for pred_col in self._predict_columns:
             answers[pred_col] = {}
-            prediction_row = {col: self._data[col][self._row_index] for col in self._data.keys()}
+            cols = [col for col in self._data.keys() if isinstance(self._data[col], list)]  # filter out class maps
+            prediction_row = {col: self._data[col][self._row_index] for col in cols}
 
             if self._transaction_output._transaction.lmd['tss']['is_timeseries'] and \
                     self._transaction_output._transaction.lmd['tss']['nr_predictions'] > 1:

--- a/mindsdb_native/libs/data_types/transaction_output_row.py
+++ b/mindsdb_native/libs/data_types/transaction_output_row.py
@@ -36,7 +36,7 @@ class TransactionOutputRow:
         answers = {}
         for pred_col in self._predict_columns:
             answers[pred_col] = {}
-            cols = [col for col in self._data.keys() if 'class_map' not in col]  # filter out class maps
+            cols = [col for col in self._data.keys() if '_class_distribution' not in col]
             prediction_row = {col: self._data[col][self._row_index] for col in cols}
 
             if self._transaction_output._transaction.lmd['tss']['is_timeseries'] and \

--- a/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
+++ b/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
@@ -561,7 +561,7 @@ class LightwoodBackend:
             if self.transaction.lmd['quick_predict']:
                 for k in predictions:
                     formated_predictions[k] = predictions[k]['predictions']
-                    if 'class_distribution' in predictions[k]:
+                    if self.transaction.lmd['output_class_distribution']:
                         formated_predictions[f'{k}_class_distribution'] = predictions[k]['class_distribution']
                         self.transaction.lmd['stats_v2'][k]['lightwood_class_map'] = predictions[k]['class_labels']
                     formated_predictions_arr.append(formated_predictions)
@@ -572,7 +572,7 @@ class LightwoodBackend:
                     continue
 
                 formated_predictions[k] = predictions[k]['predictions']
-                if 'class_distribution' in predictions[k]:
+                if self.transaction.lmd['output_class_distribution']:
                     formated_predictions[f'{k}_class_distribution'] = predictions[k]['class_distribution']
                     self.transaction.lmd['stats_v2'][k]['lightwood_class_map'] = predictions[k]['class_labels']
 

--- a/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
+++ b/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
@@ -181,6 +181,11 @@ class LightwoodBackend:
                 else:
                     lightwood_data_type = ColumnDataTypes.CATEGORICAL
 
+                # TODO: Check that tags usecase works
+                predict_proba = self.transaction.lmd['output_class_distribution']
+                if col_name in self.transaction.lmd['predict_columns'] and predict_proba:
+                    other_keys['encoder_attrs']['predict_proba'] = predict_proba
+
             elif data_subtype in (DATA_SUBTYPES.TIMESTAMP, DATA_SUBTYPES.DATE):
                 lightwood_data_type = ColumnDataTypes.DATETIME
 

--- a/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
+++ b/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
@@ -511,6 +511,9 @@ class LightwoodBackend:
         if self.transaction.lmd['quick_predict']:
             for k in predictions:
                 formated_predictions[k] = predictions[k]['predictions']
+                if 'class_distribution' in predictions[k]:
+                    formated_predictions[f'{k}_class_distribution'] = predictions[k]['class_distribution']
+                    formated_predictions[f'{k}_class_map'] = predictions[k]['class_labels']
             return formated_predictions
 
         for k in predictions:

--- a/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
+++ b/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
@@ -561,6 +561,9 @@ class LightwoodBackend:
             if self.transaction.lmd['quick_predict']:
                 for k in predictions:
                     formated_predictions[k] = predictions[k]['predictions']
+                    if 'class_distribution' in predictions[k]:
+                        formated_predictions[f'{k}_class_distribution'] = predictions[k]['class_distribution']
+                        self.transaction.lmd['stats_v2'][k]['lightwood_class_map'] = predictions[k]['class_labels']
                     formated_predictions_arr.append(formated_predictions)
                 continue
 

--- a/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
+++ b/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
@@ -216,8 +216,6 @@ class LightwoodBackend:
                 else:
                     lightwood_data_type = ColumnDataTypes.CATEGORICAL
 
-
-
             elif data_subtype in (DATA_SUBTYPES.TIMESTAMP, DATA_SUBTYPES.DATE):
                 lightwood_data_type = ColumnDataTypes.DATETIME
 

--- a/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
+++ b/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
@@ -519,6 +519,10 @@ class LightwoodBackend:
 
             formated_predictions[k] = predictions[k]['predictions']
 
+            if 'class_distribution' in predictions[k]:
+                formated_predictions[f'{k}_class_distribution'] = predictions[k]['class_distribution']
+                formated_predictions[f'{k}_class_map'] = predictions[k]['class_labels']
+
             if self.nr_predictions > 1:
                 formated_predictions[k] = [[x] for x in formated_predictions[k]]
                 for timestep_index in range(1,self.nr_predictions):

--- a/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
+++ b/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
@@ -181,7 +181,6 @@ class LightwoodBackend:
                 else:
                     lightwood_data_type = ColumnDataTypes.CATEGORICAL
 
-                # TODO: Check that tags usecase works
                 predict_proba = self.transaction.lmd['output_class_distribution']
                 if col_name in self.transaction.lmd['predict_columns'] and predict_proba:
                     other_keys['encoder_attrs']['predict_proba'] = predict_proba

--- a/tests/unit_tests/libs/controllers/test_predictor.py
+++ b/tests/unit_tests/libs/controllers/test_predictor.py
@@ -82,7 +82,7 @@ class TestPredictor(unittest.TestCase):
             to_predict='numeric_y',
             stop_training_in_x_seconds=1,
             use_gpu=False,
-            advanced_args={'debug': True}
+            advanced_args={'debug': True, 'output_class_distribution': True}
         )
 
         # Test predicting using a data frame
@@ -175,7 +175,7 @@ class TestPredictor(unittest.TestCase):
             to_predict=label_headers,
             stop_training_in_x_seconds=1,
             use_gpu=False,
-            advanced_args={'debug': True}
+            advanced_args={'debug': True, 'output_class_distribution': True}
         )
 
         results = mdb.predict(when_data=test_file_name)
@@ -318,7 +318,7 @@ class TestPredictor(unittest.TestCase):
         predictor.learn(
             from_data=df_train,
             to_predict='y',
-            advanced_args=dict(deduplicate_data=False),
+            advanced_args=dict(deduplicate_data=False, output_class_distribution=True),
             stop_training_in_x_seconds=40,
             use_gpu=False
         )
@@ -363,7 +363,7 @@ class TestPredictor(unittest.TestCase):
         predictor.learn(
             from_data=df_train,
             to_predict='tags',
-            advanced_args=dict(deduplicate_data=False),
+            advanced_args=dict(deduplicate_data=False, output_class_distribution=True),
             stop_training_in_x_seconds=60,
             use_gpu=False
         )

--- a/tests/unit_tests/libs/controllers/test_predictor.py
+++ b/tests/unit_tests/libs/controllers/test_predictor.py
@@ -319,7 +319,7 @@ class TestPredictor(unittest.TestCase):
         predictor.learn(
             from_data=df_train,
             to_predict='y',
-            advanced_args=dict(deduplicate_data=False, output_class_distribution=True),
+            advanced_args=dict(deduplicate_data=False),
             stop_training_in_x_seconds=40,
             use_gpu=False
         )

--- a/tests/unit_tests/libs/controllers/test_predictor.py
+++ b/tests/unit_tests/libs/controllers/test_predictor.py
@@ -502,4 +502,7 @@ class TestPredictor(unittest.TestCase):
 
         results = mdb.predict(when_data=data.data.iloc[[0]])
         assert 'target_class_distribution' in results._data
-        assert np.isclose(np.sum(results._data['target_class_distribution']), 1)
+        probs = results._data['target_class_distribution']
+        assert np.isclose(np.sum(probs), 1)
+        for dist in probs:
+            assert len(dist) == data.target_names.size


### PR DESCRIPTION
## Why
Having the belief distribution of a predictor is needed in certain use cases (see [L#354](https://github.com/mindsdb/lightwood/pull/354))

## How
Added `output_class_distribution` flag and corresponding test. Note that the feature is not yet supported for categorical tag columns, due to the way the Lightwood encoder operates.

(Note: the new test will pass once the L#354 PR is merged)