### PR TITLE
Removed model listing

### DIFF
--- a/mindsdb_native/libs/controllers/functional.py
+++ b/mindsdb_native/libs/controllers/functional.py
@@ -373,33 +373,3 @@ def get_model_data(model_name=None, lmd=None):
             amd['model_analysis'].append(mao)
 
     return amd
-
-
-def get_models():
-    models = []
-    predictors = [
-        x for x in Path(CONFIG.MINDSDB_STORAGE_PATH).iterdir() if
-            x.is_dir()
-            and x.joinpath('light_model_metadata.pickle').is_file()
-            and x.joinpath('heavy_model_metadata.pickle').is_file()
-    ]
-    for p in predictors:
-        model_name = p.name
-        try:
-            amd = get_model_data(model_name)
-            model = {}
-
-            KEYS = ['name', 'version', 'is_active', 'predict', 'status', 'train_end_at',
-                    'updated_at', 'created_at','current_phase', 'accuracy', 'data_source']
-
-            for k in KEYS:
-                if k in amd:
-                    model[k] = amd[k]
-                else:
-                    model[k] = None
-
-            models.append(model)
-        except Exception as e:
-            print(f"Can't adapt metadata for model: '{model_name}' when calling `get_models(), error: {e}`")
-
-    return models

--- a/tests/unit_tests/libs/controllers/test_predictor.py
+++ b/tests/unit_tests/libs/controllers/test_predictor.py
@@ -179,8 +179,7 @@ class TestPredictor(unittest.TestCase):
         )
 
         results = mdb.predict(when_data=test_file_name)
-        models = F.get_models()
-        model_data = F.get_model_data(models[0]['name'])
+        model_data = F.get_model_data('test_multilabel_prediction')
         assert model_data
 
         for i in range(len(results)):

--- a/tests/unit_tests/libs/controllers/test_predictor_timeseries.py
+++ b/tests/unit_tests/libs/controllers/test_predictor_timeseries.py
@@ -88,8 +88,7 @@ class TestPredictorTimeseries(unittest.TestCase):
         for row in [x.explanation[label_headers[0]] for x in results]:
             assert row['confidence_interval'][0] <= row['predicted_value'] <= row['confidence_interval'][1]
 
-        models = F.get_models()
-        model_data = F.get_model_data(models[0]['name'])
+        model_data = F.get_model_data('test_timeseries')
         assert model_data
 
     def test_timeseries_stepahead(self):


### PR DESCRIPTION
Removed the ability to list model, this should be a mindsdb functionality not a native functionality, as we move predictor and datasource management fully into mindsdb it makes sense to remove this.

In the future we should consider even moving automatic model saving away from native, instead opting for a lightwood like interface.