### PR TITLE
Fixes for historical_columns feature

### DIFF
--- a/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
+++ b/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
@@ -87,7 +87,9 @@ class ModelAnalyzer(BaseModule):
 
         if not self.transaction.lmd['disable_column_importance']:
             ignorable_input_columns = [x for x in input_columns if self.transaction.lmd['stats_v2'][x]['typing']['data_type'] != DATA_TYPES.FILE_PATH
-                            and (not self.transaction.lmd['tss']['is_timeseries'] or x not in self.transaction.lmd['tss']['order_by'])]
+                            and (not self.transaction.lmd['tss']['is_timeseries'] or
+                                 (x not in self.transaction.lmd['tss']['order_by'] and
+                                 x not in self.transaction.lmd['tss']['historical_columns']))]
 
             for col in ignorable_input_columns:
                 empty_input_predictions[col] = self.transaction.model_backend.predict('validate', ignore_columns=[col])

--- a/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
+++ b/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
@@ -281,9 +281,11 @@ class LightwoodBackend:
                         additional_target_config['name'] = f'{col_name}_timestep_{timestep_index}'
                         config['output_features'].append(additional_target_config)
             else:
-                if self.transaction.lmd['tss']['historical_columns']:
+                if col_name in self.transaction.lmd['tss']['historical_columns']:
                     if 'secondary_type' in col_config:
                         col_config['secondary_type'] = col_config['secondary_type']
+                    else:
+                        col_config['original_type'] = col_config['type']
                     col_config['type'] = ColumnDataTypes.TIME_SERIES
 
                 config['input_features'].append(col_config)

--- a/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
+++ b/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
@@ -284,8 +284,7 @@ class LightwoodBackend:
                 if col_name in self.transaction.lmd['tss']['historical_columns']:
                     if 'secondary_type' in col_config:
                         col_config['secondary_type'] = col_config['secondary_type']
-                    else:
-                        col_config['original_type'] = col_config['type']
+                    col_config['original_type'] = col_config['type']
                     col_config['type'] = ColumnDataTypes.TIME_SERIES
 
                 config['input_features'].append(col_config)

--- a/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
+++ b/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
@@ -21,7 +21,7 @@ def _make_pred(row):
 def _ts_to_obj(df, historical_columns):
     for hist_col in historical_columns:
         df.loc[:, hist_col] = df[hist_col].astype(object)
-        return df
+    return df
 
 
 def _ts_order_col_to_cell_lists(df, historical_columns):

--- a/tests/unit_tests/libs/controllers/test_predictor_timeseries.py
+++ b/tests/unit_tests/libs/controllers/test_predictor_timeseries.py
@@ -40,7 +40,7 @@ class TestPredictorTimeseries(unittest.TestCase):
         train_file_name = os.path.join(self.tmp_dir, 'train_data.csv')
         test_file_name = os.path.join(self.tmp_dir, 'test_data.csv')
 
-        features = generate_value_cols(['date', 'int'], data_len, ts_hours * 3600)
+        features = generate_value_cols(['date', 'int', 'int'], data_len, ts_hours * 3600)
         labels = [generate_timeseries_labels(features)]
 
         feature_headers = list(map(lambda col: col[0], features))
@@ -69,6 +69,7 @@ class TestPredictorTimeseries(unittest.TestCase):
             to_predict=label_headers,
             timeseries_settings={
                 'order_by': [feature_headers[0]],
+                'historical_columns': [feature_headers[-1]],
                 'window': 3
             },
             stop_training_in_x_seconds=10,


### PR DESCRIPTION
## Why
The `historical_columns` feature for time series was failing, see [this issue](https://github.com/mindsdb/mindsdb_native/issues/398) for more details.

## How
The fix also considers this [lightwood PR](https://github.com/mindsdb/lightwood/pull/360). In Native, there were 3 distinct bugs that this PR fixes:

1) `_ts_to_obj()` returned the modified Data Frame after changing the first column, ignoring the rest
2) `ignorable_input_columns` was keeping historical columns in. However, they cannot be removed from the input as the lightwood predictor needs them to work.
3) Logic in `_create_lightwood_config` was assigning `time_series` data type to all columns instead of only `historical_columns`

EDIT:
- A test is added to check that the feature is working correctly