### PR TITLE
Broken columns & column importance disabling

### DIFF
--- a/mindsdb_native/config/__init__.py
+++ b/mindsdb_native/config/__init__.py
@@ -23,10 +23,7 @@ class Config:
     # LOG Config settings
     DEFAULT_LOG_LEVEL = if_env_else('DEFAULT_LOG_LEVEL', CONST.DEBUG_LOG_LEVEL)
 
-    CHECK_FOR_UPDATES = if_env_else(
-        'CHECK_FOR_UPDATES',
-        if_env_else('MINDSDB_CHECK_FOR_UPDATES', True)
-    )
+    CHECK_FOR_UPDATES = if_env_else('CHECK_FOR_UPDATES', True)
 
     if CHECK_FOR_UPDATES in [0, '0', 'false', 'False']:
         CHECK_FOR_UPDATES = False

--- a/mindsdb_native/libs/controllers/transaction.py
+++ b/mindsdb_native/libs/controllers/transaction.py
@@ -267,6 +267,7 @@ class LearnTransaction(Transaction):
             self.lmd['current_phase'] = MODEL_STATUS_ERROR
             self.lmd['error_msg'] = traceback.format_exc()
             self.log.error(str(e))
+            self.save_metadata()
             raise e
 
     def run(self):

--- a/mindsdb_native/libs/controllers/transaction.py
+++ b/mindsdb_native/libs/controllers/transaction.py
@@ -231,8 +231,8 @@ class LearnTransaction(Transaction):
                 n_cols = len(self.input_data.columns)
                 n_cells = n_cols * self.lmd['data_preparation']['used_row_count']
                 if n_cols >= 80 and n_cells > int(1e5):
-                    self.log.warning('Data has too many columns, setting quick_learn to True')
-                    self.lmd['quick_learn'] = True
+                    self.log.warning('Data has too many columns, disabling column importance feature')
+                    self.lmd['disable_column_importance'] = True
 
             self._call_phase_module(module_name='DataCleaner')
             self.save_metadata()

--- a/mindsdb_native/libs/phases/type_deductor/type_deductor.py
+++ b/mindsdb_native/libs/phases/type_deductor/type_deductor.py
@@ -280,7 +280,7 @@ class TypeDeductor(BaseModule):
         stats_v2['columns'] = set(input_data.data_frame.columns.values)
         stats_v2['columns'].update(self.transaction.lmd['columns_to_ignore'])
         stats_v2['columns'] = list(stats_v2['columns'])
-        
+
         sample_settings = self.transaction.lmd['sample_settings']
         if sample_settings['sample_for_analysis']:
             sample_margin_of_error = sample_settings['sample_margin_of_error']
@@ -339,6 +339,17 @@ class TypeDeductor(BaseModule):
                             pass
                         else:
                             self.transaction.lmd['columns_to_ignore'].append(col_name)
+
+            if data_type is None or data_subtype is None:
+                self.transaction.lmd['columns_to_ignore'].append(col_name)
+                stats_v2[col_name]['broken'] = {
+                    'failed_at': 'Type detection'
+                    ,'reason': 'Unable to detect type for unknown reasons.'
+                }
+
+                if len(col_data) < 1:
+                    stats_v2[col_name]['broken']['reason'] = 'Unable to detect type due to too many empty, null, None or nan values.'
+
 
             if data_subtype_dist:
                 self.log.info(f'Data distribution for column "{col_name}" '

--- a/mindsdb_native/libs/phases/type_deductor/type_deductor.py
+++ b/mindsdb_native/libs/phases/type_deductor/type_deductor.py
@@ -340,7 +340,13 @@ class TypeDeductor(BaseModule):
                         else:
                             self.transaction.lmd['columns_to_ignore'].append(col_name)
 
+            stats_v2[col_name]['broken'] = None
             if data_type is None or data_subtype is None:
+                if col_name in self.transaction.lmd['force_column_usage'] or col_name in self.transaction.lmd['predict_columns']:
+                    err_msg = f'Failed to deduce type for critical column: {col_name}'
+                    log.error(err_msg)
+                    raise Exception(err_msg)
+
                 self.transaction.lmd['columns_to_ignore'].append(col_name)
                 stats_v2[col_name]['broken'] = {
                     'failed_at': 'Type detection'


### PR DESCRIPTION
* When we have a dataset with too many columns and a significant number of rows, instead of turning on `quick_learn` now set `disable_column_importance` to `True`, this should remove one of the costliest parts of the model analysis step for these types of dataset.
* A column can now have a `broken` flag (`None` by default, otherwise containing 2 keys: `failed_at` and `reason`), a "broken" column is one for which we fail to detect a type of subtype, usually this should only happen because the sampled values were all Nan or None. These "broken" columns are the ignored in the same way we ignore columns when they are identifiers or when the user asks us too.