### PR TITLE
Fix for creating mongo connection with empty username

### DIFF
--- a/mindsdb_native/libs/data_sources/mongodb_ds.py
+++ b/mindsdb_native/libs/data_sources/mongodb_ds.py
@@ -28,12 +28,18 @@ class MongoDS(DataSource):
     def query(self, q):
         assert isinstance(q, dict)
 
-        conn = MongoClient(
-            host=self.host,
-            port=self.port,
-            username=self.user,
-            password=self.password
-        )
+        if self.user == '':
+            conn = MongoClient(
+                host=self.host,
+                port=self.port
+            )
+        else:
+            conn = MongoClient(
+                host=self.host,
+                port=self.port,
+                username=self.user,
+                password=self.password
+            )
 
         db = conn[self.database]
         coll = db[self.collection]


### PR DESCRIPTION
**Why**

It it possible include username and password to connection sting. In that case connection will be created with `MongoClient(... ,username=None)`, which causes an error

**How**

added case for `username=None` or `username=''`