### PR TITLE
Add flag for target outlier filter

### DIFF
--- a/mindsdb_native/libs/controllers/predictor.py
+++ b/mindsdb_native/libs/controllers/predictor.py
@@ -261,7 +261,8 @@ class Predictor:
                 quick_predict = advanced_args.get('quick_predict', False),
                 apply_to_columns = advanced_args.get('apply_to_columns', {}),
                 disable_column_importance = advanced_args.get('disable_column_importance', False),
-                split_models_on = advanced_args.get('split_models_on', [])
+                split_models_on = advanced_args.get('split_models_on', []),
+                remove_target_outliers = advanced_args.get('remove_target_outliers', False)
             )
             
             if len(light_transaction_metadata['split_models_on']) > 0 and not light_transaction_metadata['quick_learn']:

--- a/mindsdb_native/libs/controllers/predictor.py
+++ b/mindsdb_native/libs/controllers/predictor.py
@@ -262,7 +262,7 @@ class Predictor:
                 apply_to_columns = advanced_args.get('apply_to_columns', {}),
                 disable_column_importance = advanced_args.get('disable_column_importance', False),
                 split_models_on = advanced_args.get('split_models_on', []),
-                remove_target_outliers = advanced_args.get('remove_target_outliers', False)
+                remove_target_outliers = advanced_args.get('remove_target_outliers', 0)
             )
             
             if len(light_transaction_metadata['split_models_on']) > 0 and not light_transaction_metadata['quick_learn']:

--- a/mindsdb_native/libs/phases/data_cleaner/data_cleaner.py
+++ b/mindsdb_native/libs/phases/data_cleaner/data_cleaner.py
@@ -74,7 +74,6 @@ class DataCleaner(BaseModule):
         if len_after_dedupe < len_before_dedupe / 2:
             self.log.warning(f'Less than half of initial rows remain after deduplication. Consider passing `deduplicate_data=False` if training results are sub-par.')
 
-
         if self.transaction.lmd['type'] == TRANSACTION_LEARN:
             # Remove rows that only contain nulls
             df.dropna(axis=0, how='all', inplace=True)
@@ -85,5 +84,15 @@ class DataCleaner(BaseModule):
                     len(df),
                     MINIMUM_ROWS
                 ))
+
+            # remove target outlier rows based on z-score
+            if self.transaction.lmd['remove_target_outliers']:
+                for target in self.transaction.lmd['predict_columns']:
+                    z_threshold = 3
+                    mean = df[target].mean()
+                    sd = df[target].std()
+                    df['scores'] = (df[target] - mean) / sd
+                    df = df[df['scores'] < z_threshold]
+                    df.pop('scores')
 
         self.transaction.input_data.data_frame = df

--- a/mindsdb_native/libs/phases/data_cleaner/data_cleaner.py
+++ b/mindsdb_native/libs/phases/data_cleaner/data_cleaner.py
@@ -86,9 +86,9 @@ class DataCleaner(BaseModule):
                 ))
 
             # remove target outlier rows based on z-score
-            if self.transaction.lmd['remove_target_outliers']:
+            if self.transaction.lmd['remove_target_outliers'] != 0:
                 for target in self.transaction.lmd['predict_columns']:
-                    z_threshold = 3
+                    z_threshold = self.transaction.lmd['remove_target_outliers']
                     mean = df[target].mean()
                     sd = df[target].std()
                     df['scores'] = (df[target] - mean) / sd

--- a/tests/unit_tests/libs/phases/data_cleaner/test_data_cleaner.py
+++ b/tests/unit_tests/libs/phases/data_cleaner/test_data_cleaner.py
@@ -65,7 +65,7 @@ class TestDataCleaner(unittest.TestCase):
             pass
         else:
             raise AssertionError
-        
+
         # Dont compare sets containing np.nan, because for some reason there can be two np.nan in a set
         # and tests fails even though everything works as expected
         notna_values = [x for x in predictor.transaction.input_data.data_frame['my_column'] if not pd.isna(x)]
@@ -112,7 +112,7 @@ class TestDataCleaner(unittest.TestCase):
 
         predictor = Predictor(name='test_force_identifier_usage')
         predictor.breakpoint = 'DataSplitter'
-    
+
         try:
             predictor.learn(
                 from_data=df,
@@ -129,3 +129,29 @@ class TestDataCleaner(unittest.TestCase):
         assert 'do_use' in predictor.transaction.input_data.train_df.columns
         assert 'numeric_id' in predictor.transaction.input_data.train_df.columns
         assert 'numeric_id' not in predictor.transaction.lmd['columns_to_ignore']
+
+    def test_remove_target_outliers(self):
+        data = pd.DataFrame({'x': np.arange(1210),
+                             'y': np.hstack([np.random.uniform(0, 1, 400),
+                                             np.random.uniform(1000, 1000, 400),
+                                             np.random.uniform(100, 1000, 400),
+                                             np.random.uniform(1e4, 2e4, 10)])
+                             })
+
+        for flag in (True, False):
+            predictor = Predictor(name=f'test_remove_target_outlier_{flag}')
+            predictor.breakpoint = 'DataCleaner'
+            try:
+                predictor.learn(from_data=data,
+                                to_predict='y',
+                                stop_training_in_x_seconds=1,
+                                advanced_args={'remove_target_outliers': flag},
+                                use_gpu=False)
+            except BreakpointException:
+                pass
+            else:
+                raise AssertionError
+            if flag:
+                assert predictor.transaction.input_data.data_frame['y'].max() <= 1000
+            else:
+                assert predictor.transaction.input_data.data_frame['y'].max() > 1000

--- a/tests/unit_tests/libs/phases/data_cleaner/test_data_cleaner.py
+++ b/tests/unit_tests/libs/phases/data_cleaner/test_data_cleaner.py
@@ -133,25 +133,24 @@ class TestDataCleaner(unittest.TestCase):
     def test_remove_target_outliers(self):
         data = pd.DataFrame({'x': np.arange(1210),
                              'y': np.hstack([np.random.uniform(0, 1, 400),
-                                             np.random.uniform(1000, 1000, 400),
-                                             np.random.uniform(100, 1000, 400),
+                                             np.random.uniform(100, 1000, 800),
                                              np.random.uniform(1e4, 2e4, 10)])
                              })
 
-        for flag in (True, False):
-            predictor = Predictor(name=f'test_remove_target_outlier_{flag}')
+        for z_score in (3, 0):
+            predictor = Predictor(name=f'test_remove_target_outlier_{z_score}')
             predictor.breakpoint = 'DataCleaner'
             try:
                 predictor.learn(from_data=data,
                                 to_predict='y',
                                 stop_training_in_x_seconds=1,
-                                advanced_args={'remove_target_outliers': flag},
+                                advanced_args={'remove_target_outliers': z_score},  # 0 -> disabled
                                 use_gpu=False)
             except BreakpointException:
                 pass
             else:
                 raise AssertionError
-            if flag:
+            if z_score:
                 assert predictor.transaction.input_data.data_frame['y'].max() <= 1000
             else:
                 assert predictor.transaction.input_data.data_frame['y'].max() > 1000


### PR DESCRIPTION
## Why
Advanced users might want to filter outliers in the target column when training a predictor.

## How
The PR adds a `remove_target_outliers` parameter that can be passed in `advanced_args`. If set, any row with an outlier target value will be filtered out.