### PR TITLE
Add output_class_distribution to get_model_data output

### DIFF
--- a/mindsdb_native/libs/controllers/functional.py
+++ b/mindsdb_native/libs/controllers/functional.py
@@ -256,6 +256,8 @@ def get_model_data(model_name=None, lmd=None):
     amd['setup_args'] = lmd.get('setup_args',None)
     amd['test_data_plot'] = lmd.get('test_data_plot',None)
 
+    amd['output_class_distribution'] = lmd.get('output_class_distribution', None)
+
     if lmd['current_phase'] == MODEL_STATUS_TRAINED:
         amd['status'] = 'complete'
     elif lmd['current_phase'] == MODEL_STATUS_ERROR:


### PR DESCRIPTION
**why**

To add `*_class_distribution ` to sql and mongo apis output, need know that model was trained with that argument.

**how**

`output_class_distribution` added to model metadata returned by `get_model_data`