### PR TITLE
Boosted absolute error for confidence in regression tasks

### DIFF
--- a/mindsdb_native/libs/helpers/conformal_helpers.py
+++ b/mindsdb_native/libs/helpers/conformal_helpers.py
@@ -39,7 +39,7 @@ def get_conf_range(X, icp, target, typing_info, lmd, std_tol=1):
         all_ranges = icp.predict(X.values)
 
         # iterate over confidence levels until spread >= a multiplier of the dataset stddev
-        for significance in range(100):
+        for significance in range(99):
             ranges = all_ranges[:, :, significance]
             spread = np.mean(ranges[:, 1] - ranges[:, 0])
             tolerance = lmd['stats_v2']['train_std_dev'][target] * std_tol

--- a/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
+++ b/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
@@ -4,7 +4,7 @@ from mindsdb_native.libs.phases.base_module import BaseModule
 from mindsdb_native.libs.helpers.general_helpers import evaluate_accuracy
 from mindsdb_native.libs.helpers.conformal_helpers import ConformalClassifierAdapter, ConformalRegressorAdapter
 from mindsdb_native.libs.helpers.conformal_helpers import SelfawareNormalizer, clean_df, get_conf_range
-from mindsdb_native.libs.helpers.conformal_helpers import BoostedSignErrorErrFunc
+from mindsdb_native.libs.helpers.conformal_helpers import BoostedAbsErrorErrFunc
 from mindsdb_native.libs.helpers.accuracy_stats import AccStats
 from mindsdb_native.libs.data_types.mindsdb_logger import log
 from sklearn.metrics import balanced_accuracy_score, r2_score
@@ -78,7 +78,7 @@ class ModelAnalyzer(BaseModule):
 
             else:
                 adapter = ConformalRegressorAdapter
-                nc_function = BoostedSignErrorErrFunc()
+                nc_function = BoostedAbsErrorErrFunc()
                 nc_class = RegressorNc
                 icp_class = IcpRegressor
 


### PR DESCRIPTION
## Why
As discovered by @ZoranPandovski, the width of prediction regions could vary wildly for the same dataset when training several predictors, which would lead to very different reported accuracies even when the predictors themselves were nearly identical in predictive capabilities. 

The issue stems from using the signed error function for nonconformity scores, which could generate non-monotonically decreasing interval widths (i.e. there was no guarantee that less confidence would mean a tighter spread). Switching to the absolute error function solves this issue, and grants stability to the width in the predicted region.

## How
The PR changes the nonconformity function used in regression to a "boosted" variant of Nonconformist's `AbsErrorErrFunc`, which interpolates the nonconf scores whenever our validation dataset has less than 100 samples. For increased precision when setting the reported accuracy, it additionally reverts to checking all possible significance levels  because optimizations made in #377 imply a much cheaper evaluation here.