### PR TITLE
Simpler unnest

### DIFF
--- a/mindsdb_native/libs/controllers/functional.py
+++ b/mindsdb_native/libs/controllers/functional.py
@@ -88,9 +88,7 @@ def analyse_dataset(from_data, sample_settings=None):
         force_column_usage = [],
         force_categorical_encoding = [],
         data_types = {},
-        data_subtypes = {},
-        unnest_constant = 0.99,
-        unnested_fields = {}
+        data_subtypes = {}
     )
 
     tx = AnalyseTransaction(

--- a/mindsdb_native/libs/controllers/predictor.py
+++ b/mindsdb_native/libs/controllers/predictor.py
@@ -274,8 +274,6 @@ class Predictor:
                 disable_column_importance = advanced_args.get('disable_column_importance', False),
                 split_models_on = advanced_args.get('split_models_on', []),
                 remove_target_outliers = advanced_args.get('remove_target_outliers', 0),
-                unnest_constant = advanced_args.get('unnest_constant', 0.99),
-                unnested_fields = advanced_args.get('unnested_fields', {}),
                 learn_started_at = time.time(),
             )
 

--- a/mindsdb_native/libs/data_sources/file_ds.py
+++ b/mindsdb_native/libs/data_sources/file_ds.py
@@ -38,7 +38,6 @@ class FileDS(DataSource):
         self.clean_rows = clean_rows
         self.custom_parser = custom_parser
         self.dialect = None
-        self.col_map = None
 
     def _handle_source(self):
         self._file_name = os.path.basename(self.file)
@@ -62,10 +61,13 @@ class FileDS(DataSource):
             file_data = df.values.tolist()
 
         elif fmt == 'json':
+            print(1)
             data.seek(0)
             json_doc = json.loads(data.read())
+            print(2)
             df = pd.json_normalize(json_doc, max_level=0)
             header = df.columns.values.tolist()
+            print(3)
             file_data = df.values.tolist()
 
         else:
@@ -76,8 +78,8 @@ class FileDS(DataSource):
         else:
             file_list_data = file_data
 
-        self.col_map = dict((col, col) for col in header)
-        return pd.DataFrame(file_list_data, columns=header), self.col_map
+        col_map = dict((col, col) for col in header)
+        return pd.DataFrame(file_list_data, columns=header), col_map
 
     def query(self, q=None):
         try:
@@ -85,7 +87,9 @@ class FileDS(DataSource):
         except Exception as e:
             log.error(f"Error creating dataframe from handled data: {e}")
             log.error("pd.read_csv data handler would be used.")
-            return pd.read_csv(self.file, sep=self.dialect.delimiter), self.col_map
+            df = pd.read_csv(self.file, sep=self.dialect.delimiter)
+            col_map = dict((col, col) for col in df.columns)
+            return df, col_map
 
     def _getDataIo(self, file):
         """

--- a/mindsdb_native/libs/data_sources/file_ds.py
+++ b/mindsdb_native/libs/data_sources/file_ds.py
@@ -61,13 +61,10 @@ class FileDS(DataSource):
             file_data = df.values.tolist()
 
         elif fmt == 'json':
-            print(1)
             data.seek(0)
             json_doc = json.loads(data.read())
-            print(2)
             df = pd.json_normalize(json_doc, max_level=0)
             header = df.columns.values.tolist()
-            print(3)
             file_data = df.values.tolist()
 
         else:

--- a/mindsdb_native/libs/data_types/data_source.py
+++ b/mindsdb_native/libs/data_types/data_source.py
@@ -11,11 +11,12 @@ from mindsdb_native.libs.constants.mindsdb import (
     DATA_SUBTYPES
 )
 from mindsdb_native.libs.data_types.mindsdb_logger import log
-from mindsdb_native.libs.helpers.json_helpers import unnest_columns
+from mindsdb_native.libs.helpers.json_helpers import unnest_df
 
-def unnest(df, col_map=None):
-    df, unnested = unnest_columns(df)
-    if unnested > 0 or col_map is None:
+def unnest(df, col_map):
+    df, unnested = unnest_df(df)
+    if unnested > 0:
+        col_map = {}
         for col in df.columns:
             col_map[col] = col
     return df, col_map
@@ -30,7 +31,7 @@ class DataSource:
         if df is not None:
             self._internal_df = df
             self._internal_col_map = self._make_colmap(df)
-            self.unnest()
+            self._internal_df, self._internal_col_map = unnest(self._internal_df, self._internal_col_map)
         else:
             self._internal_df = None
             self._internal_col_map = None
@@ -64,14 +65,14 @@ class DataSource:
             else:
                 raise ValueError(f'Invalid data subtype: {subtype}')
 
-    def extract(self):
+    def _extract_and_map(self):
         if self._internal_df is None:
             self._internal_df, self._internal_col_map = self.query(self._query)
             self._internal_df, self._internal_col_map = unnest(self._internal_df, self._internal_col_map)
 
     @property
     def df(self):
-        self.extract()
+        self._extract_and_map()
         return self._internal_df
 
     @df.setter
@@ -80,7 +81,7 @@ class DataSource:
 
     @property
     def _col_map(self):
-        self.extract()
+        self._extract_and_map()
         return self._internal_col_map
 
     @_col_map.setter
@@ -233,10 +234,12 @@ class SQLDataSource(DataSource):
                 if f"'{col}'" in query:
                     query = query.replace(f"'{col}'", col)
 
+            df, col_map = self.query(query)
+            df, col_map = unnest(df, col_map)
             if get_col_map:
-                return self.query(query)
+                return df, col_map
             else:
-                return self.query(query)[0]
+                return df, col_map
 
         except Exception as e:
             print(traceback.format_exc())
@@ -246,8 +249,7 @@ class SQLDataSource(DataSource):
     @property
     def _col_map(self):
         if self._internal_col_map is None:
-            df, cols = self.filter(where=[], limit=200, get_col_map=True)
-            _, self._internal_col_map = unnest(df, cols)
+            _, self._internal_col_map = self.filter(where=[], limit=200, get_col_map=True)
         return self._internal_col_map
 
     def name(self):

--- a/mindsdb_native/libs/data_types/data_source.py
+++ b/mindsdb_native/libs/data_types/data_source.py
@@ -153,6 +153,7 @@ class DataSource:
         if where:
             for cond in where:
                 df = self._filter_df(cond, df)
+
         return df.head(limit) if limit else df
 
     def __getstate__(self):

--- a/mindsdb_native/libs/data_types/data_source.py
+++ b/mindsdb_native/libs/data_types/data_source.py
@@ -239,7 +239,7 @@ class SQLDataSource(DataSource):
             if get_col_map:
                 return df, col_map
             else:
-                return df, col_map
+                return df
 
         except Exception as e:
             print(traceback.format_exc())

--- a/mindsdb_native/libs/helpers/json_helpers.py
+++ b/mindsdb_native/libs/helpers/json_helpers.py
@@ -34,6 +34,6 @@ def unnest_df(df):
         unnested_df.columns = [col + '.' + str(subcol) for subcol in unnested_df.columns]
         df = df.drop(columns=[col])
         for unnested_col in unnested_df.columns:
-            .df[col] = unnested_df[unnested_col]
+            df[col] = unnested_df[unnested_col]
 
     return df, unnested

--- a/mindsdb_native/libs/helpers/json_helpers.py
+++ b/mindsdb_native/libs/helpers/json_helpers.py
@@ -20,6 +20,7 @@ def try_convert_to_dict(val):
 def unnest_df(df):
     original_columns = df.columns
     unnested = 0
+    print(len(df))
     for col in original_columns:
         try:
             json_col = df[col].apply(try_convert_to_dict)
@@ -32,6 +33,7 @@ def unnest_df(df):
         unnested_df = pd.json_normalize(json_col)
         unnested_df.columns = [col + '.' + str(subcol) for subcol in unnested_df.columns]
         df = df.drop(columns=[col])
-        df = pd.concat([df,unnested_df])
+        for unnested_col in unnested_df.columns:
+            .df[col] = unnested_df[unnested_col]
 
     return df, unnested

--- a/mindsdb_native/libs/helpers/json_helpers.py
+++ b/mindsdb_native/libs/helpers/json_helpers.py
@@ -33,7 +33,8 @@ def unnest_df(df):
         unnested_df = pd.json_normalize(json_col)
         unnested_df.columns = [col + '.' + str(subcol) for subcol in unnested_df.columns]
         df = df.drop(columns=[col])
+
         for unnested_col in unnested_df.columns:
-            df[col] = unnested_df[unnested_col]
+            df[unnested_col] = unnested_df[unnested_col]
 
     return df, unnested

--- a/mindsdb_native/libs/helpers/json_helpers.py
+++ b/mindsdb_native/libs/helpers/json_helpers.py
@@ -1,5 +1,7 @@
 import json
 import pandas as pd
+import numpy as np
+
 
 def try_convert_to_dict(val):
     if pd.notnull(val):
@@ -20,7 +22,7 @@ def unnest_df(df):
     unnested = 0
     for col in original_columns:
         try:
-            json_col = df[col].apply(try_convert_to_json)
+            json_col = df[col].apply(try_convert_to_dict)
             if np.sum(len(x) for x in json_col) == 0:
                 raise Exception('Empty column !')
         except:

--- a/mindsdb_native/libs/helpers/json_helpers.py
+++ b/mindsdb_native/libs/helpers/json_helpers.py
@@ -1,0 +1,35 @@
+import json
+import pandas as pd
+
+def try_convert_to_dict(val):
+    if pd.notnull(val):
+        try:
+            obj = json.loads(val)
+            if isinstance(obj, dict):
+                return obj
+            else:
+                raise Exception('Not a json dictionary (could be an int because json.loads is weird)!')
+        except Exception:
+            return dict(val)
+    else:
+        return {}
+
+
+def unnest_df(df):
+    original_columns = df.columns
+    unnested = 0
+    for col in original_columns:
+        try:
+            json_col = df[col].apply(try_convert_to_json)
+            if np.sum(len(x) for x in json_col) == 0:
+                raise Exception('Empty column !')
+        except:
+            continue
+
+        unnested += 1
+        unnested_df = pd.json_normalize(json_col)
+        unnested_df.columns = [col + '.' + str(subcol) for subcol in unnested_df.columns]
+        df = df.drop(columns=[col])
+        df = pd.concat([df,unnested_df])
+
+    return df, unnested

--- a/tests/integration_tests/nested/test_nested_dataset.py
+++ b/tests/integration_tests/nested/test_nested_dataset.py
@@ -53,14 +53,7 @@ class TestNestedDataset(unittest.TestCase):
         self.expected_columns = ['Airport.Name', 'Time.Label', 'Time.Month', 'Time.Month Name', 'Time.Year', 'Statistics.# of Delays.Carrier', 'Statistics.# of Delays.Late Aircraft', 'Statistics.# of Delays.National Aviation System', 'Statistics.# of Delays.Security', 'Statistics.# of Delays.Weather', 'Statistics.Carriers.Names', 'Statistics.Carriers.Total', 'Statistics.Flights.Cancelled', 'Statistics.Flights.Delayed', 'Statistics.Flights.Diverted', 'Statistics.Flights.On Time', 'Statistics.Flights.Total', 'Statistics.Minutes Delayed.Carrier', 'Statistics.Minutes Delayed.Late Aircraft', 'Statistics.Minutes Delayed.National Aviation System', 'Statistics.Minutes Delayed.Security', 'Statistics.Minutes Delayed.Total', 'Statistics.Minutes Delayed.Weather']
 
     def test_1_airline_delays_train(self):
-        self.pred.learn(from_data='https://raw.githubusercontent.com/mindsdb/benchmarks/main/datasets/airline_delays/data.json', stop_training_in_x_seconds=100, to_predict='Statistics.Flights.Delayed', advanced_args={
-            'unnested_fields': {
-                'Airport': {
-                    'Name': 0.99
-                    ,'Code': 0
-                }
-            }
-        })
+        self.pred.learn(from_data='https://raw.githubusercontent.com/mindsdb/benchmarks/main/datasets/airline_delays/data.json', stop_training_in_x_seconds=100, to_predict='Statistics.Flights.Delayed')
 
     def test_2_airline_delays_data(self):
         model_data = F.get_model_data('airline_delays_train')

--- a/tests/integration_tests/nested/test_nested_dataset.py
+++ b/tests/integration_tests/nested/test_nested_dataset.py
@@ -51,9 +51,8 @@ class TestNestedDataset(unittest.TestCase):
          }
 
         self.expected_columns = ['Statistics.Minutes Delayed.Security', 'Statistics.# of Delays.Security', 'Statistics.# of Delays.Weather', 'Statistics.Minutes Delayed.Late Aircraft', 'Statistics.Flights.Total', 'Statistics.Flights.Diverted', 'Time.Month Name', 'Statistics.Flights.Delayed', 'Time.Month', 'Statistics.# of Delays.Carrier', 'Statistics.Flights.On Time', 'Time.Label', 'Airport.Name', 'Statistics.Minutes Delayed.National Aviation System', 'Airport.Code', 'Statistics.Carriers.Total', 'Statistics.Minutes Delayed.Weather', 'Time.Year', 'Statistics.# of Delays.National Aviation System', 'Statistics.Flights.Cancelled', 'Statistics.# of Delays.Late Aircraft', 'Statistics.Carriers.Names', 'Statistics.Minutes Delayed.Total', 'Statistics.Minutes Delayed.Carrier']
-        
+
     def test_1_airline_delays_train(self):
-        return
         self.pred.learn(from_data='https://raw.githubusercontent.com/mindsdb/benchmarks/main/datasets/airline_delays/data.json', stop_training_in_x_seconds=100, to_predict='Statistics.Flights.Delayed')
 
     def test_2_airline_delays_data(self):

--- a/tests/integration_tests/nested/test_nested_dataset.py
+++ b/tests/integration_tests/nested/test_nested_dataset.py
@@ -50,9 +50,10 @@ class TestNestedDataset(unittest.TestCase):
             }
          }
 
-        self.expected_columns = ['Airport.Name', 'Time.Label', 'Time.Month', 'Time.Month Name', 'Time.Year', 'Statistics.# of Delays.Carrier', 'Statistics.# of Delays.Late Aircraft', 'Statistics.# of Delays.National Aviation System', 'Statistics.# of Delays.Security', 'Statistics.# of Delays.Weather', 'Statistics.Carriers.Names', 'Statistics.Carriers.Total', 'Statistics.Flights.Cancelled', 'Statistics.Flights.Delayed', 'Statistics.Flights.Diverted', 'Statistics.Flights.On Time', 'Statistics.Flights.Total', 'Statistics.Minutes Delayed.Carrier', 'Statistics.Minutes Delayed.Late Aircraft', 'Statistics.Minutes Delayed.National Aviation System', 'Statistics.Minutes Delayed.Security', 'Statistics.Minutes Delayed.Total', 'Statistics.Minutes Delayed.Weather']
-
+        self.expected_columns = ['Statistics.Minutes Delayed.Security', 'Statistics.# of Delays.Security', 'Statistics.# of Delays.Weather', 'Statistics.Minutes Delayed.Late Aircraft', 'Statistics.Flights.Total', 'Statistics.Flights.Diverted', 'Time.Month Name', 'Statistics.Flights.Delayed', 'Time.Month', 'Statistics.# of Delays.Carrier', 'Statistics.Flights.On Time', 'Time.Label', 'Airport.Name', 'Statistics.Minutes Delayed.National Aviation System', 'Airport.Code', 'Statistics.Carriers.Total', 'Statistics.Minutes Delayed.Weather', 'Time.Year', 'Statistics.# of Delays.National Aviation System', 'Statistics.Flights.Cancelled', 'Statistics.# of Delays.Late Aircraft', 'Statistics.Carriers.Names', 'Statistics.Minutes Delayed.Total', 'Statistics.Minutes Delayed.Carrier']
+        
     def test_1_airline_delays_train(self):
+        return
         self.pred.learn(from_data='https://raw.githubusercontent.com/mindsdb/benchmarks/main/datasets/airline_delays/data.json', stop_training_in_x_seconds=100, to_predict='Statistics.Flights.Delayed')
 
     def test_2_airline_delays_data(self):
@@ -62,6 +63,7 @@ class TestNestedDataset(unittest.TestCase):
             self.assertTrue(expected_column in model_data['data_analysis_v2']['columns'])
 
         for existing_column in model_data['data_analysis_v2']['columns']:
+            print(existing_column)
             self.assertTrue(existing_column in self.expected_columns)
 
     def test_3_airline_delays_predict(self):


### PR DESCRIPTION
Added a simpler unnesting method, similar to what we were doing before, with the risk of breaking for large datasets, the only difference being that it's automatically implemented in every datasource, instead of being uniuqe to the `FileDS`.

The `FileDS` is still able to unnest json objects, but this allows the resulting columns of it (and the other datasource) to be unnested when they are json.

Also fixes and overriding error in the FileDs.

Should fix #438 and #434 