### PR TITLE
Only store column names in lmd['stats_v2'] keys

### DIFF
--- a/mindsdb_native/libs/controllers/functional.py
+++ b/mindsdb_native/libs/controllers/functional.py
@@ -248,13 +248,14 @@ def get_model_data(model_name=None, lmd=None):
     }
     if 'tss' in lmd:
         if lmd['tss']['is_timeseries']:
+            amd['timeseries']['is_timeseries'] = True
             amd['timeseries'] = {}
             amd['timeseries']['user_settings'] = lmd['tss']
 
 
-    amd['data_analysis_v2'] = lmd.get('stats_v2',None)
-    amd['setup_args'] = lmd.get('setup_args',None)
-    amd['test_data_plot'] = lmd.get('test_data_plot',None)
+    amd['data_analysis_v2'] = lmd.get('stats_v2', None)
+    amd['setup_args'] = lmd.get('setup_args', None)
+    amd['test_data_plot'] = lmd.get('test_data_plot', None)
 
     amd['output_class_distribution'] = lmd.get('output_class_distribution', None)
 

--- a/mindsdb_native/libs/controllers/functional.py
+++ b/mindsdb_native/libs/controllers/functional.py
@@ -259,6 +259,8 @@ def get_model_data(model_name=None, lmd=None):
     amd['setup_args'] = lmd.get('setup_args')
     amd['test_data_plot'] = lmd.get('test_data_plot')
     amd['columns_to_ignore'] = lmd.get('columns_to_ignore')
+    amd['columns'] = lmd.get('columns')
+    amd['predict_columns'] = lmd.get('predict_columns')
     amd['output_class_distribution'] = lmd.get('output_class_distribution')
 
     if lmd['current_phase'] == MODEL_STATUS_TRAINED:

--- a/mindsdb_native/libs/controllers/functional.py
+++ b/mindsdb_native/libs/controllers/functional.py
@@ -236,16 +236,18 @@ def get_model_data(model_name=None, lmd=None):
         pass
     elif model_name is not None:
         with MDBLock('shared', 'get_data_' + model_name):
-            lmd = load_lmd(os.path.join(CONFIG.MINDSDB_STORAGE_PATH, model_name, 'light_model_metadata.pickle'))
+            lmd = load_lmd(os.path.join(
+                CONFIG.MINDSDB_STORAGE_PATH,
+                model_name,
+                'light_model_metadata.pickle'
+            ))
 
     # ADAPTOR CODE
     amd = {}
 
     amd['data_source'] = lmd['data_source_name']
 
-    amd['timeseries'] = {
-        'is_timeseries': False
-    }
+    amd['timeseries'] = {'is_timeseries': False}
     if 'tss' in lmd:
         if lmd['tss']['is_timeseries']:
             amd['timeseries']['is_timeseries'] = True

--- a/mindsdb_native/libs/controllers/functional.py
+++ b/mindsdb_native/libs/controllers/functional.py
@@ -255,11 +255,11 @@ def get_model_data(model_name=None, lmd=None):
             amd['timeseries']['user_settings'] = lmd['tss']
 
 
-    amd['data_analysis_v2'] = lmd.get('stats_v2', None)
-    amd['setup_args'] = lmd.get('setup_args', None)
-    amd['test_data_plot'] = lmd.get('test_data_plot', None)
-
-    amd['output_class_distribution'] = lmd.get('output_class_distribution', None)
+    amd['data_analysis_v2'] = lmd.get('stats_v2')
+    amd['setup_args'] = lmd.get('setup_args')
+    amd['test_data_plot'] = lmd.get('test_data_plot')
+    amd['columns_to_ignore'] = lmd.get('columns_to_ignore')
+    amd['output_class_distribution'] = lmd.get('output_class_distribution')
 
     if lmd['current_phase'] == MODEL_STATUS_TRAINED:
         amd['status'] = 'complete'

--- a/mindsdb_native/libs/controllers/transaction.py
+++ b/mindsdb_native/libs/controllers/transaction.py
@@ -168,11 +168,6 @@ class Transaction:
         Loads the module and runs it
         """
 
-        try:
-            print(self.lmd['stats_v2'].keys())
-        except:
-            print('==PASS==')
-
         self.lmd['is_active'] = True
         self.lmd['phase'] = module_name
         module_path = convert_cammelcase_to_snake_string(module_name)
@@ -233,7 +228,7 @@ class LearnTransaction(Transaction):
 
             # quick_learn can still be set to False explicitly to disable this behavior
             if self.lmd['quick_learn'] is None:
-                n_cols = len(self.input_data.columns)
+                n_cols = len(self.lmd['columns'])
                 n_cells = n_cols * self.lmd['data_preparation']['used_row_count']
                 if n_cols >= 80 and n_cells > int(1e5):
                     self.log.warning('Data has too many columns, disabling column importance feature')
@@ -351,7 +346,7 @@ class PredictTransaction(Transaction):
         else:
             predictions_df = self.input_data.data_frame
 
-        for col in self.input_data.columns:
+        for col in self.lmd['columns']:
             if col in self.lmd['predict_columns']:
                 output_data[f'__observed_{col}'] = list(predictions_df[col])
                 output_data[col] = self.hmd['predictions'][col]
@@ -395,7 +390,7 @@ class PredictTransaction(Transaction):
                             (typing_info['data_type'] == DATA_TYPES.SEQUENTIAL and
                                 DATA_TYPES.NUMERIC in typing_info['data_type_dist'].keys()):
                         std_tol = 1
-                        tolerance = self.lmd['stats_v2']['train_std_dev'][predicted_col] * std_tol
+                        tolerance = self.lmd['stats_v2'][predicted_col]['train_std_dev'] * std_tol
                         if self.lmd['tss']['is_timeseries'] and self.lmd['tss']['nr_predictions'] > 1:
                             # bounds in time series are only given for the first forecast
                             self.hmd['icp'][predicted_col].nc_function.model.prediction_cache = \

--- a/mindsdb_native/libs/controllers/transaction.py
+++ b/mindsdb_native/libs/controllers/transaction.py
@@ -168,6 +168,11 @@ class Transaction:
         Loads the module and runs it
         """
 
+        try:
+            print(self.lmd['stats_v2'].keys())
+        except:
+            print('==PASS==')
+
         self.lmd['is_active'] = True
         self.lmd['phase'] = module_name
         module_path = convert_cammelcase_to_snake_string(module_name)

--- a/mindsdb_native/libs/data_types/transaction_data.py
+++ b/mindsdb_native/libs/data_types/transaction_data.py
@@ -9,8 +9,6 @@ class TransactionData:
         self.clean_validation_df = None
         self.historical_train_df = None
         self.historical_test_df = None
-        self.columns = []
-
         self._sample_df = None
 
     def sample_df(self,

--- a/mindsdb_native/libs/helpers/conformal_helpers.py
+++ b/mindsdb_native/libs/helpers/conformal_helpers.py
@@ -43,7 +43,7 @@ def get_conf_range(X, icp, target, typing_info, lmd, std_tol=1):
         for significance in significances:
             ranges = all_ranges[:, :, significance]
             spread = np.mean(ranges[:, 1] - ranges[:, 0])
-            tolerance = lmd['stats_v2']['train_std_dev'][target] * std_tol
+            tolerance = lmd['stats_v2'][target]['train_std_dev'] * std_tol
 
             if spread <= tolerance:
                 confidence = (99-significance)/100

--- a/mindsdb_native/libs/phases/data_cleaner/data_cleaner.py
+++ b/mindsdb_native/libs/phases/data_cleaner/data_cleaner.py
@@ -61,8 +61,8 @@ class DataCleaner(BaseModule):
         )
 
         cols_to_drop = [col for col in df.columns if col in self.transaction.lmd['columns_to_ignore']]
-        if cols_to_drop:
-            df.drop(columns=cols_to_drop, inplace=True)
+        if len(cols_to_drop) > 0:
+            df.drop(columns=cols_to_drop, inplace=True)        
 
         self._remove_missing_targets(df)
 

--- a/mindsdb_native/libs/phases/data_extractor/data_extractor.py
+++ b/mindsdb_native/libs/phases/data_extractor/data_extractor.py
@@ -201,7 +201,7 @@ class DataExtractor(BaseModule):
 
         if self.transaction.lmd['type'] == TRANSACTION_LEARN:
             for col_target in self.transaction.lmd['predict_columns']:
-                if col_target not in self.transaction.input_data.columns:
+                if col_target not in self.transaction.lmd['columns']:
                     err = 'Trying to predict column {column} but column not in source data'.format(column=col_target)
                     self.log.error(err)
                     self.transaction.error = True
@@ -238,8 +238,7 @@ class DataExtractor(BaseModule):
         # --- Replace -inf/inf values with None --- #
 
         # --- Some information about the dataset gets transplanted into transaction level variables --- #
-        self.transaction.input_data.columns = [x for x in df.columns.values.tolist() if x != 'make_predictions']
-        self.transaction.lmd['columns'] = self.transaction.input_data.columns
+        self.transaction.lmd['columns'] = [x for x in df.columns.values.tolist() if x != 'make_predictions']
         self.transaction.input_data.data_frame = df
         # --- Some information about the dataset gets transplanted into transaction level variables --- #
 

--- a/mindsdb_native/libs/phases/data_transformer/data_transformer.py
+++ b/mindsdb_native/libs/phases/data_transformer/data_transformer.py
@@ -100,7 +100,7 @@ class DataTransformer(BaseModule):
 
     def run(self, input_data):
         transaction_type = self.transaction.lmd['type']
-        for column in input_data.columns:
+        for column in self.transaction.lmd['columns']:
             if column in self.transaction.lmd['columns_to_ignore'] or column not in self.transaction.lmd['stats_v2']:
                 continue
 

--- a/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
+++ b/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
@@ -42,7 +42,6 @@ class ModelAnalyzer(BaseModule):
         self.transaction.lmd['test_data_plot'] = {}
 
         # conformal prediction confidence estimation
-        self.transaction.lmd['stats_v2']['train_std_dev'] = {}
         self.transaction.hmd['label_encoders'] = {}
         self.transaction.hmd['icp'] = {'active': False}
 
@@ -56,7 +55,7 @@ class ModelAnalyzer(BaseModule):
                                  DATA_TYPES.CATEGORICAL in typing_info['data_type_dist'].keys())
 
             fit_params = {
-                'columns_to_ignore': self.transaction.lmd['columns_to_ignore'],
+                'columns_to_ignore': [],
                 'nr_preds': self.transaction.lmd['tss'].get('nr_predictions', 0)
             }
             fit_params['columns_to_ignore'].extend([col for col in output_columns if col != target])
@@ -110,7 +109,7 @@ class ModelAnalyzer(BaseModule):
                     normalizer.prediction_cache = normal_predictions
 
                 if not is_classification:
-                    self.transaction.lmd['stats_v2']['train_std_dev'][target] = self.transaction.input_data.train_df[target].std()
+                    self.transaction.lmd['stats_v2'][target]['train_std_dev'] = self.transaction.input_data.train_df[target].std()
 
                 self.transaction.hmd['icp'][target].fit(None, None)
                 self.transaction.hmd['icp']['active'] = True
@@ -203,10 +202,7 @@ class ModelAnalyzer(BaseModule):
         for col in output_columns:
 
             # Training data accuracy
-            predictions = self.transaction.model_backend.predict(
-                'predict_on_train_data',
-                ignore_columns=self.transaction.lmd['stats_v2']['columns_to_ignore']
-            )
+            predictions = self.transaction.model_backend.predict('predict_on_train_data')
             self.transaction.lmd['train_data_accuracy'][col] = evaluate_accuracy(
                 predictions,
                 self.transaction.input_data.train_df,
@@ -216,10 +212,7 @@ class ModelAnalyzer(BaseModule):
             )
 
             # Testing data accuracy
-            predictions = self.transaction.model_backend.predict(
-                'test',
-                ignore_columns=self.transaction.lmd['stats_v2']['columns_to_ignore']
-            )
+            predictions = self.transaction.model_backend.predict('test')
             self.transaction.lmd['test_data_accuracy'][col] = evaluate_accuracy(
                 predictions,
                 test_df,
@@ -229,10 +222,7 @@ class ModelAnalyzer(BaseModule):
             )
 
             # Validation data accuracy
-            predictions = self.transaction.model_backend.predict(
-                'validate',
-                ignore_columns=self.transaction.lmd['stats_v2']['columns_to_ignore']
-            )
+            predictions = self.transaction.model_backend.predict('validate')
             self.transaction.lmd['valid_data_accuracy'][col] = evaluate_accuracy(
                 predictions,
                 validation_df,

--- a/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
+++ b/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
@@ -192,7 +192,7 @@ class LightwoodBackend:
         config['input_features'] = []
         config['output_features'] = []
 
-        for col_name in self.transaction.input_data.columns:
+        for col_name in self.transaction.lmd['columns']:
             if col_name in self.transaction.lmd['columns_to_ignore'] or col_name not in self.transaction.lmd['stats_v2']:
                 continue
 

--- a/mindsdb_native/libs/phases/type_deductor/type_deductor.py
+++ b/mindsdb_native/libs/phases/type_deductor/type_deductor.py
@@ -277,9 +277,7 @@ class TypeDeductor(BaseModule):
 
     def run(self, input_data):
         stats_v2 = defaultdict(dict)
-        stats_v2['columns'] = set(input_data.data_frame.columns.values)
-        stats_v2['columns'].update(self.transaction.lmd['columns_to_ignore'])
-        stats_v2['columns'] = list(stats_v2['columns'])
+
 
         sample_settings = self.transaction.lmd['sample_settings']
         if sample_settings['sample_for_analysis']:
@@ -339,6 +337,7 @@ class TypeDeductor(BaseModule):
                             pass
                         else:
                             self.transaction.lmd['columns_to_ignore'].append(col_name)
+                            self.transaction.input_data.data_frame.drop(columns=[col_name], inplace=True)
 
             stats_v2[col_name]['broken'] = None
             if data_type is None or data_subtype is None:
@@ -369,9 +368,9 @@ class TypeDeductor(BaseModule):
                     # Functionality is specific to mindsdb logger
                     pass
 
-        stats_v2['useable_input_columns'] = []
-        for col_name in stats_v2['columns']:
+        self.transaction.lmd['useable_input_columns'] = []
+        for col_name in self.transaction.lmd['columns']:
             if col_name not in self.transaction.lmd['columns_to_ignore'] and col_name not in self.transaction.lmd['predict_columns'] and stats_v2[col_name]['broken'] is None and stats_v2[col_name]['identifier'] is None:
-                    stats_v2['useable_input_columns'].append(col_name)
+                    self.transaction.lmd['useable_input_columns'].append(col_name)
 
         self.transaction.lmd['stats_v2'] = stats_v2

--- a/tests/integration_tests/data_sources/test_snowflake_ds.py
+++ b/tests/integration_tests/data_sources/test_snowflake_ds.py
@@ -35,4 +35,4 @@ class TestSnowflake(unittest.TestCase):
             sample_settings={'sample_percentage': 5}
         )
 
-        assert len(data_analysis['data_analysis_v2']['columns']) == 7
+        assert len(data_analysis['columns']) == 7

--- a/tests/integration_tests/nested/test_nested_dataset.py
+++ b/tests/integration_tests/nested/test_nested_dataset.py
@@ -66,9 +66,9 @@ class TestNestedDataset(unittest.TestCase):
         model_data = F.get_model_data('airline_delays_train')
 
         for expected_column in self.expected_columns:
-            self.assertTrue(expected_column in model_data['data_analysis_v2']['columns'])
+            self.assertTrue(expected_column in model_data['columns'])
 
-        for existing_column in model_data['data_analysis_v2']['columns']:
+        for existing_column in model_data['columns']:
             self.assertTrue(existing_column in self.expected_columns)
 
     def test_3_airline_delays_predict(self):

--- a/tests/unit_tests/libs/phases/data_analyzer/test_data_analyzer.py
+++ b/tests/unit_tests/libs/phases/data_analyzer/test_data_analyzer.py
@@ -35,8 +35,6 @@ class TestDataAnalyzer(unittest.TestCase):
 
         model_data = analyse_dataset(from_data=df)
         for col, col_data in model_data['data_analysis_v2'].items():
-            if col in ['columns','useable_input_columns']:
-                continue
             expected_type = test_column_types[col][0]
             expected_subtype = test_column_types[col][1]
             assert col_data['typing']['data_type'] == expected_type
@@ -152,8 +150,6 @@ class TestDataAnalyzer(unittest.TestCase):
             assert mock_function.called
 
         for col, col_data in model_data['data_analysis_v2'].items():
-            if col in ['columns','useable_input_columns']:
-                continue
             expected_type = test_column_types[col][0]
             expected_subtype = test_column_types[col][1]
             assert col_data['typing']['data_type'] == expected_type

--- a/tests/unit_tests/libs/phases/type_deductor/test_type_deductor.py
+++ b/tests/unit_tests/libs/phases/type_deductor/test_type_deductor.py
@@ -71,7 +71,7 @@ class TestTypeDeductor(unittest.TestCase):
             assert stats_v2[col_name]['typing']['data_type_dist'][expected_type] == 100
             assert stats_v2[col_name]['typing']['data_subtype_dist'][expected_subtype] == 100
 
-        for col_name in stats_v2['columns']:
+        for col_name in predictor.transaction.lmd['columns']:
             if col_name in predictor.transaction.lmd['columns_to_ignore']:
                 continue
             assert stats_v2[col_name]['identifier'] is None
@@ -83,7 +83,7 @@ class TestTypeDeductor(unittest.TestCase):
         except Exception:
             raise AssertionError
 
-        assert set(predictor.transaction.lmd['stats_v2']['columns']) == set(df.columns)
+        assert set(predictor.transaction.lmd['columns']) == set(df.columns)
 
     def test_deduce_foreign_key(self):
         """Tests that basic cases of type deduction work correctly"""


### PR DESCRIPTION
Closes https://github.com/mindsdb/mindsdb_native/issues/391

- `transaction.lmd['stats_v2']` now only contains column names.
- `'columns'`, `'train_std_dev'` keys are moved from `transaction.lmd['stats_v2']` to `transaction.lmd`
- `'columns_to_ignore'` is now only in `transaction.lmd`