### PR TITLE
Add 'limit' and 'sort' option for mongo DS

### DIFF
--- a/mindsdb_native/libs/data_sources/mongodb_ds.py
+++ b/mindsdb_native/libs/data_sources/mongodb_ds.py
@@ -8,20 +8,28 @@ from pandas.api.types import is_numeric_dtype
 from mindsdb_native.libs.data_types.data_source import DataSource
 
 class MongoDS(DataSource):
-    def __init__(self, query, collection, database='database',
+    def __init__(self, query, collection,
+                 database='database', limit=None, sort_by=None,
                  host='127.0.0.1', port=None, user=None, password=None):
+
+        """params:
+            limit: limit of requested documents
+            sort_by: sort settings. it is a dict with fields as keys
+                and '1'(ascending) '-1'(descending) as values
+                example sort_by={'id': 1, 'vendor_id': -1}"""
         super().__init__()
 
         if not isinstance(query, dict):
             raise TypeError('query must be a dict')
-        else:
-            self._query = query
+        self._query = query
 
         if not re.match(r'^mongodb(\+srv)?:\/\/', host.lower()):
             port = int(port or 27017)
 
         self.collection = collection
         self.database = database
+        self.limit = limit
+        self.sort_by = sort_by
         self.host = host
         self.port = port
         self.user = user
@@ -58,7 +66,13 @@ class MongoDS(DataSource):
         db = conn[self.database]
         coll = db[self.collection]
 
-        df = pd.DataFrame(list(coll.find(q, {'_id': 0})))
+        raw_data = coll.find(q, {'_id': 0})
+        if self.sort_by:
+            raw_data = raw_data.sort(list((k, self.sort_by[k]) for k in self.sort_by))
+        if self.limit:
+            raw_data = raw_data.limit(self.limit)
+
+        df = pd.DataFrame(list(raw_data))
         for col in df.columns:
             if not is_numeric_dtype(df[col]) or isinstance(df[col], dict):
                 df[col] = df[col].astype(str)

--- a/mindsdb_native/libs/data_sources/mongodb_ds.py
+++ b/mindsdb_native/libs/data_sources/mongodb_ds.py
@@ -8,9 +8,9 @@ from pandas.api.types import is_numeric_dtype
 from mindsdb_native.libs.data_types.data_source import DataSource
 
 class MongoDS(DataSource):
-    def __init__(self, query, collection,
-                 database='database', limit=None, sort_by=None,
-                 host='127.0.0.1', port=None, user=None, password=None):
+    def __init__(self, query, collection, database='database',
+                 host='127.0.0.1', port=None, user=None, password=None,
+                 limit=None, sort_by=None):
 
         """params:
             limit: limit of requested documents


### PR DESCRIPTION
Implements [#1097](https://github.com/mindsdb/mindsdb/issues/1097) on mindsdb_native side
How:
 - by calling `sort` and/or `limit` methods of object returned by `find`
