### PR TITLE
get_nr_procs() should always return 1 for windows

### DIFF
--- a/mindsdb_native/libs/helpers/mp_helpers.py
+++ b/mindsdb_native/libs/helpers/mp_helpers.py
@@ -1,9 +1,13 @@
+import os
 import psutil
 import multiprocessing as mp
 
 
 def get_nr_procs():
-    available_mem = psutil.virtual_memory().available
-    max_per_proc_usage = 2.6 * pow(10,9)
-    proc_count = int(min(mp.cpu_count(), available_mem // max_per_proc_usage)) - 1
-    return max(proc_count,1)
+    if os.name == 'nt':
+        return 1
+    else:
+        available_mem = psutil.virtual_memory().available
+        max_per_proc_usage = 2.6 * pow(10,9)
+        proc_count = int(min(mp.cpu_count(), available_mem // max_per_proc_usage)) - 1
+        return max(proc_count, 1)


### PR DESCRIPTION
Because there is a multiprocessing bug that causes permission error on windows