### PR TITLE
Add test for Atlas mongo datasource

### DIFF
--- a/tests/integration_tests/data_sources/test_mongodb_ds.py
+++ b/tests/integration_tests/data_sources/test_mongodb_ds.py
@@ -1,6 +1,7 @@
 import unittest
 from mindsdb_native import Predictor, F
 from . import DB_CREDENTIALS
+from mindsdb_native import MongoDS
 
 
 class TestMongoDB(unittest.TestCase):
@@ -13,7 +14,6 @@ class TestMongoDB(unittest.TestCase):
         self.COLLECTION = 'home_rentals'
 
     def test_mongodb_ds(self):
-        from mindsdb_native import MongoDS
 
         mongodb_ds = MongoDS(
             collection=self.COLLECTION,
@@ -32,3 +32,27 @@ class TestMongoDB(unittest.TestCase):
 
         assert len(mongodb_ds.filter([['rental_price', '>', 2500]], 3)) == 3
         assert len(mongodb_ds.filter([['initial_price', '<', 0]], 3)) == 0
+    
+    def test_mongodb_atlas_ds(self):
+        USER = DB_CREDENTIALS['mongodb_atlas']['user']
+        PASSWORD = DB_CREDENTIALS['mongodb_atlas']['password']
+        HOST = DB_CREDENTIALS['mongodb_atlas']['host']
+        PORT = int(DB_CREDENTIALS['mongodb_atlas']['port'])
+        DATABASE = 'sample_restaurants'
+        COLLECTION = 'restaurants'
+        atlas_ds = MongoDS(
+            collection=COLLECTION,
+            query={"grades": []},
+            host=HOST,
+            port=PORT,
+            user=USER,
+            password=PASSWORD,
+            database=DATABASE,
+            limit=5,
+                )
+        assert len(atlas_ds.df) == 5
+
+        df, _ = atlas_ds.query({"grades":{"$size": 5}})
+        assert len(df) == 5
+        df, _ = atlas_ds.query({"grades":{"$size": 45}})
+        assert len(df) == 0


### PR DESCRIPTION
Implements #433 

tests will fail until secrets are not updated. see https://github.com/mindsdb/mindsdb_server_enterprise/pull/6