### PR TITLE
Enable LightGBM mixer for time series tasks

### DIFF
--- a/mindsdb_native/libs/controllers/transaction.py
+++ b/mindsdb_native/libs/controllers/transaction.py
@@ -407,16 +407,22 @@ class PredictTransaction(Transaction):
                                     output_data[f'{predicted_col}_confidence'][sample_idx] = significance
                                     conf_range = list(sample[:, idx])
 
-                                    # for positive numerical domains
                                     if self.lmd['stats_v2'][predicted_col].get('positive_domain', False):
                                         conf_range[0] = max(0, conf_range[0])
+
                                     output_data[f'{predicted_col}_confidence_range'][sample_idx] = conf_range
                                     break
                             else:
                                 output_data[f'{predicted_col}_confidence'][sample_idx] = 0.9901  # default
                                 bounds = sample[:, 0]
                                 sigma = (bounds[1] - bounds[0]) / 2
-                                output_data[f'{predicted_col}_confidence_range'][sample_idx] = [bounds[0] - sigma, bounds[1] + sigma]
+                                conf_range = [bounds[0] - sigma, bounds[1] + sigma]
+
+                                if self.lmd['stats_v2'][predicted_col].get('positive_domain', False):
+                                    conf_range[0] = max(0, conf_range[0])
+
+                                output_data[f'{predicted_col}_confidence_range'][sample_idx] = conf_range
+
                     # categorical
                     elif typing_info['data_type'] == DATA_TYPES.CATEGORICAL or \
                             (typing_info['data_type'] == DATA_TYPES.SEQUENTIAL and

--- a/mindsdb_native/libs/controllers/transaction.py
+++ b/mindsdb_native/libs/controllers/transaction.py
@@ -408,7 +408,7 @@ class PredictTransaction(Transaction):
                                     conf_range = list(sample[:, idx])
 
                                     if self.lmd['stats_v2'][predicted_col].get('positive_domain', False):
-                                        conf_range[0] = max(0, conf_range[0])
+                                        conf_range[0] = max(0.0, conf_range[0])
 
                                     output_data[f'{predicted_col}_confidence_range'][sample_idx] = conf_range
                                     break
@@ -419,7 +419,7 @@ class PredictTransaction(Transaction):
                                 conf_range = [bounds[0] - sigma, bounds[1] + sigma]
 
                                 if self.lmd['stats_v2'][predicted_col].get('positive_domain', False):
-                                    conf_range[0] = max(0, conf_range[0])
+                                    conf_range[0] = max(0.0, conf_range[0])
 
                                 output_data[f'{predicted_col}_confidence_range'][sample_idx] = conf_range
 

--- a/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
+++ b/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
@@ -21,6 +21,7 @@ from nonconformist.nc import RegressorNc, ClassifierNc, MarginErrFunc
 class ModelAnalyzer(BaseModule):
     def run(self):
         np.seterr(divide='warn', invalid='warn')
+        np.random.seed(0)
         """
         # Runs the model on the validation set in order to evaluate the accuracy and confidence of future predictions
         """

--- a/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
+++ b/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
@@ -236,7 +236,6 @@ class LightwoodBackend:
 
             elif data_subtype == DATA_SUBTYPES.ARRAY:
                 lightwood_data_type = ColumnDataTypes.TIME_SERIES
-                # self.nn_mixer_only = True
 
             else:
                 self.transaction.log.error(f'The lightwood model backend is unable to handle data of type {data_type} and subtype {data_subtype} !')
@@ -244,7 +243,6 @@ class LightwoodBackend:
 
             if self.transaction.lmd['tss']['is_timeseries'] and col_name in self.transaction.lmd['tss']['order_by']:
                 lightwood_data_type = ColumnDataTypes.TIME_SERIES
-                # self.nn_mixer_only = True
 
             grouped_by = self.transaction.lmd['tss'].get('group_by', [])
             col_config = {

--- a/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
+++ b/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
@@ -236,7 +236,7 @@ class LightwoodBackend:
 
             elif data_subtype == DATA_SUBTYPES.ARRAY:
                 lightwood_data_type = ColumnDataTypes.TIME_SERIES
-                self.nn_mixer_only = True
+                # self.nn_mixer_only = True
 
             else:
                 self.transaction.log.error(f'The lightwood model backend is unable to handle data of type {data_type} and subtype {data_subtype} !')
@@ -244,7 +244,7 @@ class LightwoodBackend:
 
             if self.transaction.lmd['tss']['is_timeseries'] and col_name in self.transaction.lmd['tss']['order_by']:
                 lightwood_data_type = ColumnDataTypes.TIME_SERIES
-                self.nn_mixer_only = True
+                # self.nn_mixer_only = True
 
             grouped_by = self.transaction.lmd['tss'].get('group_by', [])
             col_config = {


### PR DESCRIPTION
## Why
Having more than one mixer can lead to improved predictions.

## How
There was a check/guard in place to force `NnMixer` usage for time series tasks which this PR removes.

Additionally, this fixes a small bug in the confidence range reported for the default case in numerical tasks (when we're not able to find a bound with a specified width tolerance).