### PR TITLE
Max processes advanced arg

### DIFF
--- a/mindsdb_native/libs/controllers/predictor.py
+++ b/mindsdb_native/libs/controllers/predictor.py
@@ -275,7 +275,7 @@ class Predictor:
                 split_models_on = advanced_args.get('split_models_on', []),
                 remove_target_outliers = advanced_args.get('remove_target_outliers', 0),
                 remove_columns_with_missing_targets = advanced_args.get('remove_columns_with_missing_targets', True),
-                max_processes = advanced_args.get('max_processes', 8),
+                max_processes = advanced_args.get('max_processes', None),
                 max_per_proc_usage = advanced_args.get('max_per_proc_usage', None),
                 learn_started_at = time.time(),
             )

--- a/mindsdb_native/libs/controllers/predictor.py
+++ b/mindsdb_native/libs/controllers/predictor.py
@@ -275,6 +275,8 @@ class Predictor:
                 split_models_on = advanced_args.get('split_models_on', []),
                 remove_target_outliers = advanced_args.get('remove_target_outliers', 0),
                 remove_columns_with_missing_targets = advanced_args.get('remove_columns_with_missing_targets', True),
+                max_processes = advanced_args.get('max_processes', 8),
+                max_per_proc_usage = advanced_args.get('max_per_proc_usage', None),
                 learn_started_at = time.time(),
             )
 

--- a/mindsdb_native/libs/helpers/mp_helpers.py
+++ b/mindsdb_native/libs/helpers/mp_helpers.py
@@ -10,7 +10,7 @@ def get_nr_procs(max_processes=None, max_per_proc_usage=None, df=None):
         available_mem = psutil.virtual_memory().available
         if max_per_proc_usage is None or type(max_per_proc_usage) not in (int, float):
             max_per_proc_usage = 2.6 * pow(10, 9)
-            if df:
+            if df is not None:
                 max_per_proc_usage += df.memory_usage(index=True, deep=True).sum()
         proc_count = int(min(mp.cpu_count(), available_mem // max_per_proc_usage)) - 1
         if isinstance(max_processes, int):

--- a/mindsdb_native/libs/helpers/mp_helpers.py
+++ b/mindsdb_native/libs/helpers/mp_helpers.py
@@ -12,7 +12,6 @@ def get_nr_procs(max_processes=None, max_per_proc_usage=None, df=None):
             max_per_proc_usage = 2.6 * pow(10, 9)
             if df:
                 max_per_proc_usage += df.memory_usage(index=True, deep=True).sum()
-                print('MP MEM DF:', df.memory_usage(index=True, deep=True).sum())
         proc_count = int(min(mp.cpu_count(), available_mem // max_per_proc_usage)) - 1
         if isinstance(max_processes, int):
             proc_count = min(proc_count, max_processes)

--- a/mindsdb_native/libs/helpers/mp_helpers.py
+++ b/mindsdb_native/libs/helpers/mp_helpers.py
@@ -3,13 +3,16 @@ import psutil
 import multiprocessing as mp
 
 
-def get_nr_procs(max_processes=None, max_per_proc_usage=None):
+def get_nr_procs(max_processes=None, max_per_proc_usage=None, df=None):
     if os.name == 'nt':
         return 1
     else:
         available_mem = psutil.virtual_memory().available
         if max_per_proc_usage is None or type(max_per_proc_usage) not in (int, float):
             max_per_proc_usage = 2.6 * pow(10, 9)
+            if df:
+                max_per_proc_usage += df.memory_usage(index=True, deep=True).sum()
+                print('MP MEM DF:', df.memory_usage(index=True, deep=True).sum())
         proc_count = int(min(mp.cpu_count(), available_mem // max_per_proc_usage)) - 1
         if isinstance(max_processes, int):
             proc_count = min(proc_count, max_processes)

--- a/mindsdb_native/libs/helpers/mp_helpers.py
+++ b/mindsdb_native/libs/helpers/mp_helpers.py
@@ -3,11 +3,14 @@ import psutil
 import multiprocessing as mp
 
 
-def get_nr_procs():
+def get_nr_procs(max_processes=None, max_per_proc_usage=None):
     if os.name == 'nt':
         return 1
     else:
         available_mem = psutil.virtual_memory().available
-        max_per_proc_usage = 2.6 * pow(10,9)
+        if max_per_proc_usage is None or type(max_per_proc_usage) not in (int, float):
+            max_per_proc_usage = 2.6 * pow(10, 9)
         proc_count = int(min(mp.cpu_count(), available_mem // max_per_proc_usage)) - 1
+        if isinstance(max_processes, int):
+            proc_count = min(proc_count, max_processes)
         return max(proc_count, 1)

--- a/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
+++ b/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
@@ -134,7 +134,7 @@ class LightwoodBackend:
             df_arr = [original_df]
 
         if len(original_df) > 500:
-            pool = mp.Pool(processes=get_nr_procs())
+            pool = mp.Pool(processes=get_nr_procs(self.transaction.lmd('max_processes'), self.transaction.lmd('max_per_proc_usage')))
             # Make type `object` so that dataframe cells can be python lists
             df_arr = pool.map(partial(_ts_to_obj, historical_columns=ob_arr + self.transaction.lmd['tss']['historical_columns']), df_arr)
             df_arr = pool.map(partial(_ts_order_col_to_cell_lists, historical_columns=ob_arr + self.transaction.lmd['tss']['historical_columns']), df_arr)

--- a/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
+++ b/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
@@ -135,7 +135,8 @@ class LightwoodBackend:
 
         if len(original_df) > 500:
             nr_procs = get_nr_procs(self.transaction.lmd.get('max_processes', None),
-                                    self.transaction.lmd.get('max_per_proc_usage', None))
+                                    self.transaction.lmd.get('max_per_proc_usage', None),
+                                    df_arr)
             self.transaction.log.info(f'Using {nr_procs} processes to reshape.')
             pool = mp.Pool(processes=nr_procs)
             # Make type `object` so that dataframe cells can be python lists

--- a/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
+++ b/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
@@ -134,7 +134,9 @@ class LightwoodBackend:
             df_arr = [original_df]
 
         if len(original_df) > 500:
-            pool = mp.Pool(processes=get_nr_procs(self.transaction.lmd('max_processes'), self.transaction.lmd('max_per_proc_usage')))
+            nr_procs = get_nr_procs(self.transaction.lmd.get('max_processes', None),
+                                    self.transaction.lmd.get('max_per_proc_usage', None))
+            pool = mp.Pool(processes=nr_procs)
             # Make type `object` so that dataframe cells can be python lists
             df_arr = pool.map(partial(_ts_to_obj, historical_columns=ob_arr + self.transaction.lmd['tss']['historical_columns']), df_arr)
             df_arr = pool.map(partial(_ts_order_col_to_cell_lists, historical_columns=ob_arr + self.transaction.lmd['tss']['historical_columns']), df_arr)

--- a/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
+++ b/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
@@ -136,7 +136,7 @@ class LightwoodBackend:
         if len(original_df) > 500:
             nr_procs = get_nr_procs(self.transaction.lmd.get('max_processes', None),
                                     self.transaction.lmd.get('max_per_proc_usage', None),
-                                    df_arr)
+                                    original_df)
             self.transaction.log.info(f'Using {nr_procs} processes to reshape.')
             pool = mp.Pool(processes=nr_procs)
             # Make type `object` so that dataframe cells can be python lists

--- a/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
+++ b/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
@@ -136,6 +136,7 @@ class LightwoodBackend:
         if len(original_df) > 500:
             nr_procs = get_nr_procs(self.transaction.lmd.get('max_processes', None),
                                     self.transaction.lmd.get('max_per_proc_usage', None))
+            self.transaction.log.info(f'Using {nr_procs} processes to reshape.')
             pool = mp.Pool(processes=nr_procs)
             # Make type `object` so that dataframe cells can be python lists
             df_arr = pool.map(partial(_ts_to_obj, historical_columns=ob_arr + self.transaction.lmd['tss']['historical_columns']), df_arr)

--- a/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
+++ b/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
@@ -21,25 +21,20 @@ def _make_pred(row):
 
 
 def _ts_to_obj(df, historical_columns):
-    print(f'proc: {mp.current_process()}, start _ts_to_obj, df {df.memory_usage(index=True, deep=True).sum()}')
     for hist_col in historical_columns:
         df.loc[:, hist_col] = df[hist_col].astype(object)
-    print(f'proc: {mp.current_process()}, end _ts_to_obj, df {df.memory_usage(index=True, deep=True).sum()}')
     return df
 
 
 def _ts_order_col_to_cell_lists(df, historical_columns):
-    print(f'proc: {mp.current_process()}, start _ts_order_col_to_cell_lists, df {df.memory_usage(index=True, deep=True).sum()}')
     for order_col in historical_columns:
         for ii in range(len(df)):
             label = df.index.values[ii]
             df.at[label, order_col] = [df.at[label, order_col]]
-    print(f'proc: {mp.current_process()}, end _ts_order_col_to_cell_lists, df {df.memory_usage(index=True, deep=True).sum()}')
     return df
 
 
 def _ts_add_previous_rows(df, historical_columns, window):
-    print(f'proc: {mp.current_process()}, start _ts_add_previous_rows, df {df.memory_usage(index=True, deep=True).sum()}')
     for order_col in historical_columns:
         for i in range(len(df)):
             previous_indexes = [*range(max(0, i - window), i)]
@@ -55,12 +50,10 @@ def _ts_add_previous_rows(df, historical_columns, window):
                 [0] * (1 + window - len(df.iloc[i][order_col]))
             )
             df.iloc[i][order_col].reverse()
-    print(f'proc: {mp.current_process()}, end _ts_add_previous_rows, df {df.memory_usage(index=True, deep=True).sum()}')
     return df
 
 
 def _ts_add_previous_target(df, predict_columns, nr_predictions, window):
-    print(f'proc: {mp.current_process()}, start _ts_add_previous_target, df {df.memory_usage(index=True, deep=True).sum()}')
     for target_column in predict_columns:
         previous_target_values = list(df[target_column])
         del previous_target_values[-1]
@@ -81,7 +74,6 @@ def _ts_add_previous_target(df, predict_columns, nr_predictions, window):
                 next_target_value_arr.append(0)
             # @TODO: Maybe ignore the rows with `None` next targets for training
             df[f'{target_column}_timestep_{timestep_index}'] = next_target_value_arr
-    print(f'proc: {mp.current_process()}, end _ts_add_previous_target, df {df.memory_usage(index=True, deep=True).sum()}')
     return df
 
 
@@ -117,8 +109,6 @@ class LightwoodBackend:
             else:
                 secondary_type_dict[col] = ColumnDataTypes.NUMERIC
 
-        print(f'proc: {mp.current_process()}, stop nr 1')
-
         # Convert order_by columns to numbers (note, rows are references to mutable rows in `original_df`)
         for _, row in original_df.iterrows():
             for col in ob_arr:
@@ -142,8 +132,6 @@ class LightwoodBackend:
                 df_arr.append(df.sort_values(by=ob_arr))
         else:
             df_arr = [original_df]
-
-        print(f'proc: {mp.current_process()}, stop nr 2')
 
         if len(original_df) > 500:
             nr_procs = get_nr_procs(self.transaction.lmd.get('max_processes', None),
@@ -174,9 +162,6 @@ class LightwoodBackend:
 
         if len(combined_df) == 0:
             raise Exception(f'Not enough historical context to make a timeseries prediction. Please provide a number of rows greater or equal to the window size. If you can\'t get enough rows, consider lowering your window size. If you want to force timeseries predictions lacking historical context please set the `allow_incomplete_history` advanced argument to `True`, but this might lead to subpar predictions.')
-
-        print(
-            f'proc: {mp.current_process()}, reshaped df memusage {combined_df.memory_usage(index=True, deep=True).sum()}')
 
         df_gb_map = None
         if len(df_arr) > 1 and (self.transaction.lmd['quick_learn'] or self.transaction.lmd['quick_predict']):
@@ -352,13 +337,8 @@ class LightwoodBackend:
         if self.transaction.lmd['tss']['is_timeseries']:
             self.transaction.log.debug('Reshaping data into timeseries format, this may take a while !')
 
-            self.transaction.log.error(f'train DF memusage: {self.transaction.input_data.train_df.memory_usage(index=True, deep=True).sum()}')
             train_df, secondary_type_dict, _, train_df_gb_map = self._ts_reshape(self.transaction.input_data.train_df)
-            self.transaction.log.error(f'reshaped train DF memusage: {train_df.memory_usage(index=True, deep=True).sum()}')
-
-            self.transaction.log.error(f'reshaping test, DF memusage: {self.transaction.input_data.test_df.memory_usage(index=True, deep=True).sum()}')
             test_df, _, _, test_df_gb_map = self._ts_reshape(self.transaction.input_data.test_df)
-            self.transaction.log.error(f'reshaped test DF memusage: {test_df.memory_usage(index=True, deep=True).sum()}')
 
             self.transaction.log.debug('Done reshaping data into timeseries format !')
         else:

--- a/mindsdb_native/libs/phases/type_deductor/type_deductor.py
+++ b/mindsdb_native/libs/phases/type_deductor/type_deductor.py
@@ -304,8 +304,9 @@ class TypeDeductor(BaseModule):
         else:
             sample_df = input_data.data_frame
 
-        if get_nr_procs() > 1 and False:
-            pool = mp.Pool(processes=get_nr_procs())
+        nr_procs = get_nr_procs(self.transaction.lmd('max_processes'), self.transaction.lmd('max_per_proc_usage'))
+        if nr_procs > 1 and False:
+            pool = mp.Pool(processes=nr_procs)
             # Make type `object` so that dataframe cells can be python lists
             answer_arr = pool.map(partial(get_column_data_type, lmd=self.transaction.lmd), [
                 (sample_df[x].dropna(), input_data.data_frame[x], x) for x in sample_df.columns.values
@@ -335,8 +336,8 @@ class TypeDeductor(BaseModule):
             stats_v2[col_name]['typing'] = type_data
             stats_v2[col_name]['additional_info'] = additional_info
 
-        if get_nr_procs() > 1:
-            pool = mp.Pool(processes=get_nr_procs())
+        if nr_procs > 1:
+            pool = mp.Pool(processes=nr_procs)
             answer_arr = pool.map(get_identifier_description_mp, [
                 (input_data.data_frame[x],
                     x,

--- a/mindsdb_native/libs/phases/type_deductor/type_deductor.py
+++ b/mindsdb_native/libs/phases/type_deductor/type_deductor.py
@@ -305,7 +305,8 @@ class TypeDeductor(BaseModule):
             sample_df = input_data.data_frame
 
         nr_procs = get_nr_procs(self.transaction.lmd.get('max_processes', None),
-                                self.transaction.lmd.get('max_per_proc_usage', None))
+                                self.transaction.lmd.get('max_per_proc_usage', None),
+                                sample_df)
         if nr_procs > 1 and False:
             self.transaction.log.info(f'Using {nr_procs} processes to deduct types.')
             pool = mp.Pool(processes=nr_procs)

--- a/mindsdb_native/libs/phases/type_deductor/type_deductor.py
+++ b/mindsdb_native/libs/phases/type_deductor/type_deductor.py
@@ -298,6 +298,7 @@ class TypeDeductor(BaseModule):
 
             sample_size = len(sample_df)
             population_size = len(input_data.data_frame)
+            self.transaction.log.error(f'DF memusage: {sample_df.memory_usage()}')
             self.transaction.log.info(f'Analyzing a sample of {sample_size} '
                                       f'from a total population of {population_size},'
                                       f' this is equivalent to {round(sample_size*100/population_size, 1)}% of your data.')

--- a/mindsdb_native/libs/phases/type_deductor/type_deductor.py
+++ b/mindsdb_native/libs/phases/type_deductor/type_deductor.py
@@ -304,7 +304,8 @@ class TypeDeductor(BaseModule):
         else:
             sample_df = input_data.data_frame
 
-        nr_procs = get_nr_procs(self.transaction.lmd('max_processes'), self.transaction.lmd('max_per_proc_usage'))
+        nr_procs = get_nr_procs(self.transaction.lmd.get('max_processes', None),
+                                self.transaction.lmd.get('max_per_proc_usage', None))
         if nr_procs > 1 and False:
             pool = mp.Pool(processes=nr_procs)
             # Make type `object` so that dataframe cells can be python lists

--- a/mindsdb_native/libs/phases/type_deductor/type_deductor.py
+++ b/mindsdb_native/libs/phases/type_deductor/type_deductor.py
@@ -298,7 +298,6 @@ class TypeDeductor(BaseModule):
 
             sample_size = len(sample_df)
             population_size = len(input_data.data_frame)
-            self.transaction.log.error(f'DF memusage: {sample_df.memory_usage(index=True, deep=True).sum()}')
             self.transaction.log.info(f'Analyzing a sample of {sample_size} '
                                       f'from a total population of {population_size},'
                                       f' this is equivalent to {round(sample_size*100/population_size, 1)}% of your data.')

--- a/mindsdb_native/libs/phases/type_deductor/type_deductor.py
+++ b/mindsdb_native/libs/phases/type_deductor/type_deductor.py
@@ -298,7 +298,7 @@ class TypeDeductor(BaseModule):
 
             sample_size = len(sample_df)
             population_size = len(input_data.data_frame)
-            self.transaction.log.error(f'DF memusage: {sample_df.memory_usage()}')
+            self.transaction.log.error(f'DF memusage: {sample_df.memory_usage(index=True, deep=True).sum()}')
             self.transaction.log.info(f'Analyzing a sample of {sample_size} '
                                       f'from a total population of {population_size},'
                                       f' this is equivalent to {round(sample_size*100/population_size, 1)}% of your data.')
@@ -355,9 +355,6 @@ class TypeDeductor(BaseModule):
             for x in sample_df.columns.values:
                 answer = get_identifier_description_mp([input_data.data_frame[x], x, stats_v2[x]['typing']['data_type'], stats_v2[x]['typing']['data_subtype'], stats_v2[x]['additional_info']])
                 answer_arr.append(answer)
-
-
-
 
         for i, col_name in enumerate(sample_df.columns.values):
             # work with the full data

--- a/mindsdb_native/libs/phases/type_deductor/type_deductor.py
+++ b/mindsdb_native/libs/phases/type_deductor/type_deductor.py
@@ -307,6 +307,7 @@ class TypeDeductor(BaseModule):
         nr_procs = get_nr_procs(self.transaction.lmd.get('max_processes', None),
                                 self.transaction.lmd.get('max_per_proc_usage', None))
         if nr_procs > 1 and False:
+            self.transaction.log.info(f'Using {nr_procs} processes to deduct types.')
             pool = mp.Pool(processes=nr_procs)
             # Make type `object` so that dataframe cells can be python lists
             answer_arr = pool.map(partial(get_column_data_type, lmd=self.transaction.lmd), [


### PR DESCRIPTION
## Why
To give advanced users more control over how many processes to spawn and/or how much base memory each worker would use. 

## How
Adding the respective arguments and modifying the `mp_helper.get_nr_procs` method a bit.