### PR TITLE
Anomaly detection for numerical time series

### DIFF
--- a/mindsdb_native/libs/controllers/predictor.py
+++ b/mindsdb_native/libs/controllers/predictor.py
@@ -61,9 +61,6 @@ def _prepare_timeseries_settings(user_provided_settings):
         use_previous_target=True,
         nr_predictions=1,
         historical_columns=[],
-        anomaly_detection=True,
-        anomaly_error_rate=None,  # (None or float) forces specific confidence level in ICP
-        anomaly_cooldown=1,  # (Int) in time steps; implicitly assumes series are regularly spaced
     )
 
     if len(user_provided_settings) > 0:
@@ -431,7 +428,12 @@ class Predictor:
                 use_database_history = advanced_args.get('use_database_history', False),
                 allow_incomplete_history = advanced_args.get('allow_incomplete_history', False),
                 quick_predict = advanced_args.get('quick_predict', False),
-                return_raw_predictions = advanced_args.get('return_raw_predictions', False)
+                return_raw_predictions = advanced_args.get('return_raw_predictions', False),
+                anomaly_detection = advanced_args.get('anomaly_detection', True),
+                # (None or float) forces specific confidence level in ICP
+                anomaly_error_rate = advanced_args.get('anomaly_error_rate', None),
+                # (Int) in time steps; implicitly assumes series are regularly spaced
+                anomaly_cooldown = advanced_args.get('anomaly_cooldown', 1),
             )
 
             self.transaction = PredictTransaction(

--- a/mindsdb_native/libs/controllers/predictor.py
+++ b/mindsdb_native/libs/controllers/predictor.py
@@ -54,14 +54,16 @@ def _prepare_sample_settings(user_provided_settings,
 
 def _prepare_timeseries_settings(user_provided_settings):
     timeseries_settings = dict(
-        is_timeseries=False
-        ,group_by=None
-        ,order_by=None
-        ,window=None
-        ,use_previous_target=True
-        ,nr_predictions=1
-        ,historical_columns=[]
-        ,anomaly_detection=True
+        is_timeseries=False,
+        group_by=None,
+        order_by=None,
+        window=None,
+        use_previous_target=True,
+        nr_predictions=1,
+        historical_columns=[],
+        anomaly_detection=True,
+        anomaly_error_rate=None,  # (None or float) forces specific confidence level in ICP
+        anomaly_cooldown=1,  # (Int) in time steps; implicitly assumes series are regularly spaced
     )
 
     if len(user_provided_settings) > 0:
@@ -71,7 +73,6 @@ def _prepare_timeseries_settings(user_provided_settings):
             raise Exception(f'Invalid timeseries settings, you must specify a window size')
         else:
             timeseries_settings['is_timeseries'] = True
-
 
     for k in user_provided_settings:
         if k in timeseries_settings:

--- a/mindsdb_native/libs/controllers/predictor.py
+++ b/mindsdb_native/libs/controllers/predictor.py
@@ -61,6 +61,7 @@ def _prepare_timeseries_settings(user_provided_settings):
         ,use_previous_target=True
         ,nr_predictions=1
         ,historical_columns=[]
+        ,anomaly_detection=True
     )
 
     if len(user_provided_settings) > 0:

--- a/mindsdb_native/libs/controllers/predictor.py
+++ b/mindsdb_native/libs/controllers/predictor.py
@@ -58,9 +58,9 @@ def _prepare_timeseries_settings(user_provided_settings):
         group_by=None,
         order_by=None,
         window=None,
-        use_previous_target=True,
-        nr_predictions=1,
-        historical_columns=[],
+        use_previous_target=True,  # adds target previous values to the TS encoder input data
+        nr_predictions=1,          # forecasting window, instances nr_predictions columns by displacing each target
+        historical_columns=[],     # each of these gets encoded by its own TS encoder
     )
 
     if len(user_provided_settings) > 0:
@@ -430,9 +430,13 @@ class Predictor:
                 quick_predict = advanced_args.get('quick_predict', False),
                 return_raw_predictions = advanced_args.get('return_raw_predictions', False),
                 anomaly_detection = advanced_args.get('anomaly_detection', True),
+
                 # (None or float) forces specific confidence level in ICP
                 anomaly_error_rate = advanced_args.get('anomaly_error_rate', None),
-                # (Int) in time steps; implicitly assumes series are regularly spaced
+
+                # (Int) ignores anomaly detection for N steps after an
+                # initial anomaly triggers the cooldown period;
+                # implicitly assumes series are regularly spaced
                 anomaly_cooldown = advanced_args.get('anomaly_cooldown', 1),
             )
 

--- a/mindsdb_native/libs/controllers/transaction.py
+++ b/mindsdb_native/libs/controllers/transaction.py
@@ -478,6 +478,14 @@ class PredictTransaction(Transaction):
                     confs = [[a, b] for a, b in zip(result['lower'], result['upper'])]
                     output_data[f'{predicted_col}_confidence_range'] = confs
 
+                    # anomaly detection
+                    if self.lmd['tss']['is_timeseries'] and self.lmd['tss']['anomaly_detection']:
+                        anomalies = []
+                        for (l, u), t in zip(output_data[f'{predicted_col}_confidence_range'],
+                                             output_data[f'__observed_{predicted_col}']):
+                            anomalies.append(not l <= t <= u)
+                        output_data[f'{predicted_col}_anomaly'] = anomalies
+
         else:
             for predicted_col in self.lmd['predict_columns']:
                 output_data[f'{predicted_col}_confidence'] = [None] * len(output_data[predicted_col])

--- a/mindsdb_native/libs/controllers/transaction.py
+++ b/mindsdb_native/libs/controllers/transaction.py
@@ -1,5 +1,5 @@
 from mindsdb_native.libs.helpers.general_helpers import *
-from mindsdb_native.libs.helpers.confidence_helpers import get_numerical_conf_range, get_categorical_conf
+from mindsdb_native.libs.helpers.confidence_helpers import get_numerical_conf_range, get_categorical_conf, get_anomalies
 from mindsdb_native.libs.helpers.conformal_helpers import restore_icp_state, clear_icp_state
 from mindsdb_native.libs.data_types.transaction_data import TransactionData
 from mindsdb_native.libs.data_types.transaction_output_data import (
@@ -485,13 +485,9 @@ class PredictTransaction(Transaction):
 
                     # anomaly detection
                     if is_anomaly_task:
-                        anomalies = []
-                        for (l, u), t in zip(output_data[f'{predicted_col}_confidence_range'],
-                                             output_data[f'__observed_{predicted_col}']):
-                            if t is not None:
-                                anomalies.append(not l <= t <= u)
-                            else:
-                                anomalies.append(None)
+                        anomalies = get_anomalies(output_data[f'{predicted_col}_confidence_range'],
+                                                  output_data[f'__observed_{predicted_col}'],
+                                                  cooldown=self.lmd['tss']['anomaly_cooldown'])
                         output_data[f'{predicted_col}_anomaly'] = anomalies
 
         else:

--- a/mindsdb_native/libs/controllers/transaction.py
+++ b/mindsdb_native/libs/controllers/transaction.py
@@ -381,7 +381,9 @@ class PredictTransaction(Transaction):
                                   DATA_TYPES.CATEGORICAL in typing_info['data_type_dist'].keys())) and \
                                   typing_info['data_subtype'] != DATA_SUBTYPES.TAGS
 
-                is_anomaly_task = self.lmd['tss']['is_timeseries'] and self.lmd['tss']['anomaly_detection']
+                is_anomaly_task = is_numerical and \
+                                  self.lmd['tss']['is_timeseries'] and \
+                                  self.lmd['tss']['anomaly_detection']
 
                 if (is_numerical or is_categorical) and self.hmd['icp'].get(predicted_col, False):
 

--- a/mindsdb_native/libs/controllers/transaction.py
+++ b/mindsdb_native/libs/controllers/transaction.py
@@ -483,7 +483,10 @@ class PredictTransaction(Transaction):
                         anomalies = []
                         for (l, u), t in zip(output_data[f'{predicted_col}_confidence_range'],
                                              output_data[f'__observed_{predicted_col}']):
-                            anomalies.append(not l <= t <= u)
+                            if t is not None:
+                                anomalies.append(not l <= t <= u)
+                            else:
+                                anomalies.append(None)
                         output_data[f'{predicted_col}_anomaly'] = anomalies
 
         else:

--- a/mindsdb_native/libs/data_types/transaction_output_row.py
+++ b/mindsdb_native/libs/data_types/transaction_output_row.py
@@ -69,7 +69,7 @@ class TransactionOutputRow:
             else:
                 answers[pred_col]['predicted_value'] = prediction_row[pred_col]
 
-            if prediction_row.get(f'{pred_col}_anomaly', None) is not None and \
+            if f'{pred_col}_anomaly' in prediction_row.keys() and \
                     self._transaction_output._transaction.lmd.get('anomaly_detection', False):
                 answers[pred_col]['anomaly'] = prediction_row[f'{pred_col}_anomaly']
 

--- a/mindsdb_native/libs/data_types/transaction_output_row.py
+++ b/mindsdb_native/libs/data_types/transaction_output_row.py
@@ -69,7 +69,8 @@ class TransactionOutputRow:
             else:
                 answers[pred_col]['predicted_value'] = prediction_row[pred_col]
 
-            if self._transaction_output._transaction.lmd.get('anomaly_detection', False):
+            if prediction_row.get(f'{pred_col}_anomaly', None) is not None and \
+                    self._transaction_output._transaction.lmd.get('anomaly_detection', False):
                 answers[pred_col]['anomaly'] = prediction_row[f'{pred_col}_anomaly']
 
             if prediction_row.get(f'{pred_col}_confidence') is not None:

--- a/mindsdb_native/libs/data_types/transaction_output_row.py
+++ b/mindsdb_native/libs/data_types/transaction_output_row.py
@@ -69,6 +69,9 @@ class TransactionOutputRow:
             else:
                 answers[pred_col]['predicted_value'] = prediction_row[pred_col]
 
+            if self._transaction_output._transaction.lmd.get('anomaly_detection', False):
+                answers[pred_col]['anomaly'] = prediction_row[f'{pred_col}_anomaly']
+
             if prediction_row.get(f'{pred_col}_confidence') is not None:
                 answers[pred_col]['confidence'] = round(prediction_row[f'{pred_col}_confidence'], 4)
                 quality = 'very confident'

--- a/mindsdb_native/libs/helpers/confidence_helpers.py
+++ b/mindsdb_native/libs/helpers/confidence_helpers.py
@@ -69,7 +69,14 @@ def set_conf_range(X, icp, target, typing_info, lmd, std_tol=1, group='__default
 def get_numerical_conf_range(all_confs, predicted_col, stats, std_tol=1, group='__default', error_rate=None):
     """ Gets prediction bounds for numerical targets, based on ICP estimation and width tolerance
         error_rate: pre-determined error rate for the ICP, used in anomaly detection tasks to adjust the
-        threshold sensitivity
+        threshold sensitivity.
+
+        :param all_confs: numpy.ndarray, all possible bounds depending on confidence level
+        :param predicted_col: str
+        :param stats: dict
+        :param std_tol: int
+        :param group: str
+        :param error_rate: float (1 >= , can be specified to bypass automatic confidence/bound detection
     """
     if not isinstance(error_rate, float):
         error_rate = None
@@ -101,6 +108,7 @@ def get_numerical_conf_range(all_confs, predicted_col, stats, std_tol=1, group='
         conf_ranges = np.array(conf_ranges)
     else:
         # fixed error rate
+        error_rate = max(0.01, min(1.0, error_rate))
         conf = 1 - error_rate
         conf_idx = int(100*error_rate) - 1
         conf_ranges = all_confs[:, :, conf_idx]
@@ -113,7 +121,10 @@ def get_numerical_conf_range(all_confs, predicted_col, stats, std_tol=1, group='
 
 def get_categorical_conf(all_confs, conf_candidates):
     """ Gets ICP confidence estimation for categorical targets.
-    Prediction set is always unitary and includes only the predicted label. """
+    Prediction set is always unitary and includes only the predicted label.
+    :param all_confs: numpy.ndarray, all possible label sets depending on confidence level
+    :param conf_candidates: list, includes preset confidence levels to check
+    """
     significances = []
     for sample_idx in range(all_confs.shape[0]):
         sample = all_confs[sample_idx, :, :]

--- a/mindsdb_native/libs/helpers/confidence_helpers.py
+++ b/mindsdb_native/libs/helpers/confidence_helpers.py
@@ -124,3 +124,27 @@ def get_categorical_conf(all_confs, conf_candidates):
         else:
             significances.append(0.005)  # default: not confident label is the predicted one
     return significances
+
+
+def get_anomalies(bounds, observed_series, cooldown=1):
+    anomalies = []
+    counter = 0
+
+    for (l, u), t in zip(bounds, observed_series):
+        if t is not None:
+            anomaly = not (l <= t <= u)
+
+            if anomaly and (counter == 0 or counter >= cooldown):
+                anomalies.append(anomaly)  # new anomaly event triggers, reset counter
+                counter = 1
+            elif anomaly and counter < cooldown:
+                anomalies.append(False)  # overwrite as not anomalous if still in cooldown
+                counter += 1
+            else:
+                anomalies.append(anomaly)
+                counter = 0
+        else:
+            anomalies.append(None)
+            counter += 1
+
+    return anomalies

--- a/mindsdb_native/libs/helpers/confidence_helpers.py
+++ b/mindsdb_native/libs/helpers/confidence_helpers.py
@@ -66,15 +66,15 @@ def set_conf_range(X, icp, target, typing_info, lmd, std_tol=1, group='__default
     return 0.005, np.zeros((X.shape[0], 2))
 
 
-def get_numerical_conf_range(all_confs, predicted_col, stats, std_tol=1, group='__default', conf=None):
+def get_numerical_conf_range(all_confs, predicted_col, stats, std_tol=1, group='__default', error_rate=None):
     """ Gets prediction bounds for numerical targets, based on ICP estimation and width tolerance
-        conf: pre-determined error rate for the ICP, used in anomaly detection tasks to adjust the
+        error_rate: pre-determined error rate for the ICP, used in anomaly detection tasks to adjust the
         threshold sensitivity
     """
-    if not isinstance(conf, float):
-        conf = None
+    if not isinstance(error_rate, float):
+        error_rate = None
 
-    if conf is None:
+    if error_rate is None:
         significances = []
         conf_ranges = []
         std_dev = stats[predicted_col]['train_std_dev'][group]
@@ -101,8 +101,9 @@ def get_numerical_conf_range(all_confs, predicted_col, stats, std_tol=1, group='
         conf_ranges = np.array(conf_ranges)
     else:
         # fixed error rate
-        idx = int(conf*100)
-        conf_ranges = all_confs[:, :, idx]
+        conf = 1 - error_rate
+        conf_idx = int(100*error_rate) - 1
+        conf_ranges = all_confs[:, :, conf_idx]
         significances = [conf for _ in range(conf_ranges.shape[0])]
 
     if stats[predicted_col].get('positive_domain', False):


### PR DESCRIPTION
## Why
Add anomaly detection support for numerical time series (see [M#1116](https://github.com/mindsdb/mindsdb/issues/1116)).

This first working iteration uses an approach based on confidence ranges that the conformal predictor outputs. Any incoming true value that falls outside the predicted bounds will be flagged as an anomaly under the `output_data[f'{target}_anomaly]` boolean field in the `PredictTransaction`.

Anomaly detection is enabled by default (relevant argument is `anomaly_detection=True` in `advanced_args` for `Predictor.predict()`).

To customize the sensitivity to each particular use case, two additional parameters are exposed in `advanced_args`:
1. `anomaly_error_rate` (float): forces an error rate in the ICP confidence estimator. This directly impacts the sensitivity of anomaly detection. Default behavior (`None`) determines this automatically.
2. `anomaly_cooldown` (int): number of timesteps that will be flagged as an anomaly after a triggering event. This is to compensate the predictor response, and assumes a series is regularly spaced. 

## How
Given the confidence-based approach, the implementation is fairly straightforward by flagging in `PredictTransaction` any real value that is not within bounds. Some minor refactoring was needed to pass the additional arguments as well.