### PR TITLE
Hotfix 2.38.1

### DIFF
--- a/mindsdb_native/__about__.py
+++ b/mindsdb_native/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'mindsdb_native'
 __package_name__ = 'mindsdb_native'
-__version__ = '2.38.0'
+__version__ = '2.38.1'
 __description__ = "MindsDB's goal is to make it very simple for developers to use the power of artificial neural networks in their projects."
 __email__ = "jorge@mindsdb.com"
 __author__ = 'MindsDB Inc'

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ wheel >= 0.32.2
 attrs >= 18.2.0
 pytz >= 2018.5
 scipy >= 1.1.0, <= 1.4.1
+scikit-learn >= 0.22.1, <= 0.23.2
 colorlog >= 4.0.2
 ImageHash == 4.0
 imageio == 2.5.0


### PR DESCRIPTION
Restores `scikit-learn <= 0.23.2` requirement 