### PR TITLE
Flag for fixed confidence level

### DIFF
--- a/mindsdb_native/libs/controllers/predictor.py
+++ b/mindsdb_native/libs/controllers/predictor.py
@@ -252,6 +252,7 @@ class Predictor:
                 output_class_distribution = advanced_args.get('output_class_distribution', True),
                 use_selfaware_model = advanced_args.get('use_selfaware_model', True),
                 deduplicate_data = advanced_args.get('deduplicate_data', True),
+                fixed_confidence = advanced_args.get('fixed_confidence', None),
                 null_values = advanced_args.get('null_values', {}),
                 data_split_indexes = advanced_args.get('data_split_indexes', None),
                 tags_delimiter = advanced_args.get('tags_delimiter', ','),
@@ -422,6 +423,7 @@ class Predictor:
                 allow_incomplete_history = advanced_args.get('allow_incomplete_history', False),
                 quick_predict = advanced_args.get('quick_predict', False),
                 return_raw_predictions = advanced_args.get('return_raw_predictions', False),
+                fixed_confidence = advanced_args.get('fixed_confidence', None),
                 anomaly_detection = advanced_args.get('anomaly_detection', True),
 
                 # (None or float) forces specific confidence level in ICP

--- a/mindsdb_native/libs/controllers/transaction.py
+++ b/mindsdb_native/libs/controllers/transaction.py
@@ -432,10 +432,13 @@ class PredictTransaction(Transaction):
                     # convert (B, 2, 99) into (B, 2) given width or error rate constraints
                     if is_numerical:
                         error_rate = self.lmd['anomaly_error_rate'] if is_anomaly_task else None
+                        # significances = 0.8
+                        # confs = all_confs[:, :, int(100*(1-significances))-1]
                         significances, confs = get_numerical_conf_range(all_confs,
                                                                         predicted_col,
                                                                         self.lmd['stats_v2'],
                                                                         error_rate=error_rate)
+                        print(f"SIGNIFICANCE AT {significances}")
                         result.loc[X.index, 'lower'] = confs[:, 0]
                         result.loc[X.index, 'upper'] = confs[:, 1]
                     else:

--- a/mindsdb_native/libs/controllers/transaction.py
+++ b/mindsdb_native/libs/controllers/transaction.py
@@ -398,6 +398,9 @@ class PredictTransaction(Transaction):
                         normalizer.prediction_cache = self.hmd['predictions'].get(f'{predicted_col}_selfaware_scores',
                                                                                   None)
                         icp_X['__mdb_selfaware_scores'] = normalizer.prediction_cache
+                        print(icp_X['__mdb_selfaware_scores'])
+
+                    print(f"Normalizer @ inference: {normalizer is not None}")
 
                     # get ICP predictions
                     result = pd.DataFrame(index=icp_X.index, columns=['lower', 'upper', 'significance'])
@@ -432,12 +435,12 @@ class PredictTransaction(Transaction):
                     # convert (B, 2, 99) into (B, 2) given width or error rate constraints
                     if is_numerical:
                         error_rate = self.lmd['anomaly_error_rate'] if is_anomaly_task else None
-                        # significances = 0.8
-                        # confs = all_confs[:, :, int(100*(1-significances))-1]
-                        significances, confs = get_numerical_conf_range(all_confs,
-                                                                        predicted_col,
-                                                                        self.lmd['stats_v2'],
-                                                                        error_rate=error_rate)
+                        significances = 0.99
+                        confs = all_confs[:, :, int(100*(1-significances))-1]
+                        # significances, confs = get_numerical_conf_range(all_confs,
+                        #                                                 predicted_col,
+                        #                                                 self.lmd['stats_v2'],
+                        #                                                 error_rate=error_rate)
                         print(f"SIGNIFICANCE AT {significances}")
                         result.loc[X.index, 'lower'] = confs[:, 0]
                         result.loc[X.index, 'upper'] = confs[:, 1]

--- a/mindsdb_native/libs/helpers/confidence_helpers.py
+++ b/mindsdb_native/libs/helpers/confidence_helpers.py
@@ -38,7 +38,6 @@ def set_conf_range(X, icp, target, typing_info, lmd, std_tol=1, group='__default
 
         # iterate over confidence levels until spread >= a multiplier of the dataset stddev
         if significance is not None:
-            print(f'using fixed significance {significance}')
             conf = int(100*(1-significance))
             return significance, all_ranges[:, :, conf]
         else:

--- a/mindsdb_native/libs/helpers/confidence_helpers.py
+++ b/mindsdb_native/libs/helpers/confidence_helpers.py
@@ -26,8 +26,10 @@ def clean_df(df, target, transaction, is_classification, extra_params):
     return df, y
 
 
-def set_conf_range(X, icp, target, typing_info, lmd, std_tol=1, group='__default'):
-    """ Sets confidence level and returns it plus predictions regions """
+def set_conf_range(X, icp, target, typing_info, lmd, std_tol=1, group='__default', significance=None):
+    """ Sets confidence level and returns it plus predictions regions
+    significance: desired confidence level. can be preset 0 < x <= 0.99
+    """
     # numerical
     if typing_info['data_type'] == DATA_TYPES.NUMERIC or (typing_info['data_type'] == DATA_TYPES.SEQUENTIAL and
                                                           DATA_TYPES.NUMERIC in typing_info['data_type_dist'].keys()):
@@ -35,22 +37,27 @@ def set_conf_range(X, icp, target, typing_info, lmd, std_tol=1, group='__default
         all_ranges = icp.predict(X.values)
 
         # iterate over confidence levels until spread >= a multiplier of the dataset stddev
-        for tol in [std_tol, std_tol + 1, std_tol + 2]:
-            for significance in range(99):
-                ranges = all_ranges[:, :, significance]
-                spread = np.mean(ranges[:, 1] - ranges[:, 0])
-                tolerance = lmd['stats_v2'][target]['train_std_dev'][group] * tol
-
-                if spread <= tolerance:
-                    confidence = (99 - significance) / 100
-                    if lmd['stats_v2'][target].get('positive_domain', False):
-                        ranges[ranges < 0] = 0
-                    return confidence, ranges
+        if significance is not None:
+            print(f'using fixed significance {significance}')
+            conf = int(100*(1-significance))
+            return significance, all_ranges[:, :, conf]
         else:
-            ranges = all_ranges[:, :, 0]
-            if lmd['stats_v2'][target].get('positive_domain', False):
-                ranges[ranges < 0] = 0
-            return 0.9901, ranges
+            for tol in [std_tol, std_tol + 1, std_tol + 2]:
+                for significance in range(99):
+                    ranges = all_ranges[:, :, significance]
+                    spread = np.mean(ranges[:, 1] - ranges[:, 0])
+                    tolerance = lmd['stats_v2'][target]['train_std_dev'][group] * tol
+
+                    if spread <= tolerance:
+                        confidence = (99 - significance) / 100
+                        if lmd['stats_v2'][target].get('positive_domain', False):
+                            ranges[ranges < 0] = 0
+                        return confidence, ranges
+            else:
+                ranges = all_ranges[:, :, 0]
+                if lmd['stats_v2'][target].get('positive_domain', False):
+                    ranges[ranges < 0] = 0
+                return 0.9901, ranges
 
     # categorical
     elif (typing_info['data_type'] == DATA_TYPES.CATEGORICAL or  # categorical

--- a/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
+++ b/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
@@ -99,7 +99,7 @@ class ModelAnalyzer(BaseModule):
                 if is_selfaware:
                     norm_params = {'output_column': target}
                     normalizer = SelfawareNormalizer(fit_params=norm_params)
-                    # normalizer.prediction_cache = normal_predictions.get(f'{target}_selfaware_scores', None)
+                    normalizer.prediction_cache = normal_predictions.get(f'{target}_selfaware_scores', None)
                 else:
                     normalizer = None
 

--- a/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
+++ b/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
@@ -100,12 +100,10 @@ class ModelAnalyzer(BaseModule):
                     norm_params = {'output_column': target}
                     normalizer = SelfawareNormalizer(fit_params=norm_params)
                     # normalizer.prediction_cache = normal_predictions.get(f'{target}_selfaware_scores', None)
-                    print(normalizer.prediction_cache)
                 else:
                     normalizer = None
 
-                print(f"Normalizer: {normalizer is not None}")
-                fixed_significance = 0.99
+                fixed_significance = self.transaction.lmd.get('fixed_confidenece', None)
 
                 # instance the ICP
                 nc = nc_class(model, nc_function, normalizer=normalizer)

--- a/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
+++ b/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
@@ -99,9 +99,13 @@ class ModelAnalyzer(BaseModule):
                 if is_selfaware:
                     norm_params = {'output_column': target}
                     normalizer = SelfawareNormalizer(fit_params=norm_params)
-                    normalizer.prediction_cache = normal_predictions.get(f'{target}_selfaware_scores', None)
+                    # normalizer.prediction_cache = normal_predictions.get(f'{target}_selfaware_scores', None)
+                    print(normalizer.prediction_cache)
                 else:
                     normalizer = None
+
+                print(f"Normalizer: {normalizer is not None}")
+                fixed_significance = 0.99
 
                 # instance the ICP
                 nc = nc_class(model, nc_function, normalizer=normalizer)
@@ -144,7 +148,8 @@ class ModelAnalyzer(BaseModule):
                 self.transaction.hmd['icp'][target]['__default'].calibrate(icp_df.values, y)
 
                 # get confidence estimation for validation dataset
-                _, ranges = set_conf_range(icp_df, icp, target, typing_info, self.transaction.lmd)
+                _, ranges = set_conf_range(icp_df, icp, target, typing_info, self.transaction.lmd,
+                                           significance=fixed_significance)
                 if not is_classification:
                     result_df = pd.DataFrame(index=self.transaction.input_data.cached_val_df.index, columns=['lower', 'upper'])
                     result_df.loc[icp_df.index, 'lower'] = ranges[:, 0]
@@ -192,7 +197,8 @@ class ModelAnalyzer(BaseModule):
 
                         # get bounds for relevant rows in validation dataset
                         _, group_ranges = set_conf_range(icp_df, icps[frozenset(group)], target, typing_info,
-                                                         self.transaction.lmd, group=frozenset(group))
+                                                         self.transaction.lmd, group=frozenset(group),
+                                                         significance=fixed_significance)
                         # save group bounds
                         if not is_classification:
                             result_df.loc[icp_df.index, 'lower'] = group_ranges[:, 0]

--- a/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
+++ b/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
@@ -589,6 +589,11 @@ class LightwoodBackend:
                             if len(model_confidence_dict[k]) <= i:
                                 model_confidence_dict[k].append([])
                             conf = predictions[k][confidence_name][i]
+                            # @TODO We should make sure lightwood never returns confidences above or bellow 0 and 1
+                            if conf < 0:
+                                conf = 0
+                            if conf > 1:
+                                conf = 1
                             model_confidence_dict[k][i].append(conf)
 
                 if 'selfaware_confidences' in predictions[k]:

--- a/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
+++ b/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
@@ -580,7 +580,6 @@ class LightwoodBackend:
 
                 model_confidence_dict = {}
                 for confidence_name in ['selfaware_confidences', 'loss_confidences']:
-                    # caveat: self-aware output is a score rather than a confidence
                     if confidence_name in predictions[k]:
                         if k not in model_confidence_dict:
                             model_confidence_dict[k] = []

--- a/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
+++ b/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
@@ -13,6 +13,7 @@ from lightwood.constants.lightwood import ColumnDataTypes
 from mindsdb_native.libs.constants.mindsdb import *
 from mindsdb_native.config import *
 from mindsdb_native.libs.helpers.general_helpers import evaluate_accuracy
+from mindsdb_native.libs.helpers.conformal_helpers import t_softmax
 from mindsdb_native.libs.helpers.mp_helpers import get_nr_procs
 
 
@@ -589,10 +590,10 @@ class LightwoodBackend:
                                 model_confidence_dict[k].append([])
                             conf = predictions[k][confidence_name][i]
                             # @TODO We should make sure lightwood never returns confidences above or bellow 0 and 1
-                            if conf < 0:
-                                conf = 0
-                            if conf > 1:
-                                conf = 1
+                            # if conf < 0:
+                            #     conf = 0
+                            # if conf > 1:
+                            #     conf = 1
                             model_confidence_dict[k][i].append(conf)
 
                 if 'selfaware_confidences' in predictions[k]:

--- a/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
+++ b/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
@@ -13,7 +13,6 @@ from lightwood.constants.lightwood import ColumnDataTypes
 from mindsdb_native.libs.constants.mindsdb import *
 from mindsdb_native.config import *
 from mindsdb_native.libs.helpers.general_helpers import evaluate_accuracy
-from mindsdb_native.libs.helpers.conformal_helpers import t_softmax
 from mindsdb_native.libs.helpers.mp_helpers import get_nr_procs
 
 
@@ -580,7 +579,8 @@ class LightwoodBackend:
                             formated_predictions[k][i].append(predictions[f'{k}_timestep_{timestep_index}']['predictions'][i])
 
                 model_confidence_dict = {}
-                for confidence_name in ['selfaware_confidences','loss_confidences']:
+                for confidence_name in ['selfaware_confidences', 'loss_confidences']:
+                    # caveat: self-aware output is a score rather than a confidence
                     if confidence_name in predictions[k]:
                         if k not in model_confidence_dict:
                             model_confidence_dict[k] = []
@@ -589,11 +589,6 @@ class LightwoodBackend:
                             if len(model_confidence_dict[k]) <= i:
                                 model_confidence_dict[k].append([])
                             conf = predictions[k][confidence_name][i]
-                            # @TODO We should make sure lightwood never returns confidences above or bellow 0 and 1
-                            # if conf < 0:
-                            #     conf = 0
-                            # if conf > 1:
-                            #     conf = 1
                             model_confidence_dict[k][i].append(conf)
 
                 if 'selfaware_confidences' in predictions[k]:


### PR DESCRIPTION
## Why
Sometimes, it might be desirable to fix a confidence level for the ICPs, instead of using our automatic procedure.
## How
Modify confidence methods so that the automatic procedure is bypassed if confidence is fixed.