### PR TITLE
better date subtype detection

### DIFF
--- a/mindsdb_native/libs/controllers/predictor.py
+++ b/mindsdb_native/libs/controllers/predictor.py
@@ -271,8 +271,6 @@ class Predictor:
                 remove_columns_with_missing_targets = advanced_args.get('remove_columns_with_missing_targets', True),
                 max_processes = advanced_args.get('max_processes', None),
                 max_per_proc_usage = advanced_args.get('max_per_proc_usage', None),
-                date_fmts = advanced_args.get('date_fmts', None),
-                datetime_fmts = advanced_args.get('datetime_fmts', None),
 
                 learn_started_at = time.time(),
             )

--- a/mindsdb_native/libs/phases/data_analyzer/data_analyzer.py
+++ b/mindsdb_native/libs/phases/data_analyzer/data_analyzer.py
@@ -47,7 +47,7 @@ def clean_int_and_date_data(col_data, log, stats_v2, col_name):
                 cleaned_data.append(clean_float(ele))
             except Exception as e1:
                 try:
-                    fmt = stats_v2[col_name]['additional_info']['date_fmt']
+                    fmt = stats_v2[col_name]['date_fmt']
                     cleaned_data.append(
                         datetime.datetime.strptime(str(ele), fmt).timestamp()
                     )

--- a/mindsdb_native/libs/phases/data_transformer/data_transformer.py
+++ b/mindsdb_native/libs/phases/data_transformer/data_transformer.py
@@ -121,7 +121,7 @@ class DataTransformer(BaseModule):
                         column,
                         _standardize_date,
                         transaction_type,
-                        fmt=self.transaction.lmd['stats_v2'][column]['additional_info']['date_fmt']
+                        fmt=self.transaction.lmd['stats_v2'][column]['date_fmt']
                     )
 
                 elif data_subtype == DATA_SUBTYPES.TIMESTAMP:
@@ -130,7 +130,7 @@ class DataTransformer(BaseModule):
                         column,
                         _standardize_datetime,
                         transaction_type,
-                        fmt=self.transaction.lmd['stats_v2'][column]['additional_info']['date_fmt']
+                        fmt=self.transaction.lmd['stats_v2'][column]['date_fmt']
                     )
 
             if data_type == DATA_TYPES.CATEGORICAL:
@@ -148,7 +148,7 @@ class DataTransformer(BaseModule):
 
             if self.transaction.hmd['model_backend'] == 'lightwood':
                 if data_type == DATA_TYPES.DATE:
-                    self._apply_to_all_data(input_data, column, _standardize_datetime, transaction_type, fmt=self.transaction.lmd['stats_v2'][column]['additional_info']['date_fmt'])
+                    self._apply_to_all_data(input_data, column, _standardize_datetime, transaction_type, fmt=self.transaction.lmd['stats_v2'][column]['date_fmt'])
                     self._apply_to_all_data(input_data, column, _lightwood_datetime_processing, transaction_type)
                     self._apply_to_all_data(input_data, column, _handle_nan, transaction_type)
 

--- a/mindsdb_native/libs/phases/data_transformer/data_transformer.py
+++ b/mindsdb_native/libs/phases/data_transformer/data_transformer.py
@@ -115,23 +115,13 @@ class DataTransformer(BaseModule):
                     self._apply_to_all_data(input_data, column, _try_round, transaction_type)
 
             if data_type == DATA_TYPES.DATE:
-                if data_subtype == DATA_SUBTYPES.DATE:
-                    self._apply_to_all_data(
-                        input_data,
-                        column,
-                        _standardize_date,
-                        transaction_type,
-                        fmt=self.transaction.lmd['stats_v2'][column]['date_fmt']
-                    )
-
-                elif data_subtype == DATA_SUBTYPES.TIMESTAMP:
-                    self._apply_to_all_data(
-                        input_data,
-                        column,
-                        _standardize_datetime,
-                        transaction_type,
-                        fmt=self.transaction.lmd['stats_v2'][column]['date_fmt']
-                    )
+                self._apply_to_all_data(
+                    input_data,
+                    column,
+                    _standardize_date,
+                    transaction_type,
+                    fmt=self.transaction.lmd['stats_v2'][column]['date_fmt']
+                )
 
             if data_type == DATA_TYPES.CATEGORICAL:
                 if data_subtype == DATA_SUBTYPES.TAGS:

--- a/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
+++ b/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
@@ -121,7 +121,7 @@ class LightwoodBackend:
                         try:
                             row[col] = datetime.datetime.strptime(
                                 row[col],
-                                self.transaction.lmd['stats_v2'][col]['additional_info']['date_fmt']
+                                self.transaction.lmd['stats_v2'][col]['date_fmt']
                             )
                         except (TypeError, ValueError):
                             pass

--- a/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
+++ b/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
@@ -132,6 +132,7 @@ class LightwoodBackend:
                     try:
                         row[col] = float(row[col])
                     except ValueError:
+                        raise Exception(self.transaction.lmd['stats_v2'][col]['date_fmt'])
                         raise ValueError(f'Failed to order based on column: "{col}" due to faulty value: {row[col]}')
 
         if len(gb_arr) > 0:

--- a/mindsdb_native/libs/phases/type_deductor/type_deductor.py
+++ b/mindsdb_native/libs/phases/type_deductor/type_deductor.py
@@ -181,7 +181,7 @@ def get_column_data_type(arg_tup, lmd):
 
     type_dist, subtype_dist, new_additional_info = count_data_types_in_column(
         data,
-        date_fmts=lmd.get('date_fmts') or ['%Y-%m-%d', '%Y/%m/%d', '%d.%m.%Y', '%Y/%m', '%Y-%m'],
+        date_fmts=lmd.get('date_fmts') or ['%Y-%m-%d', '%Y/%m/%d', '%d.%m.%Y', '%Y/%m', '%Y-%m', '%m/%d/%Y'],
         datetime_fmts=lmd.get('datetime_fmts') or ['%Y-%m-%d %H:%M:%S', '%Y/%m/%d %H:%M:%S', '%d.%m.%Y %H:%M:%S', '%Y-%m-%dT%H:%M:%S.%f%Z', '%Y-%m-%dT%H:%M:%S.%f%z', '%Y-%m-%dT%H:%M:%S.%f']
     )
 

--- a/mindsdb_native/libs/phases/type_deductor/type_deductor.py
+++ b/mindsdb_native/libs/phases/type_deductor/type_deductor.py
@@ -37,7 +37,9 @@ DATE_FMTS = [
     '%d.%m.%Y',
     '%Y/%m',
     '%Y-%m',
-    '%d/%m/%Y'
+    '%d/%m/%Y',
+    '%m/%d/%Y',
+    '%m/%d/%y',
 ]
 
 DATETIME_FMTS = [
@@ -155,7 +157,7 @@ def count_data_types_in_column(data):
             else:
                 subtype, best_fmt = get_date_column_subtype(data)
                 return DATA_TYPES.DATE, subtype, best_fmt
-        return None, None
+        return None, None, None
 
     type_checkers = [type_check_numeric,
                      type_check_sequence,
@@ -165,7 +167,8 @@ def count_data_types_in_column(data):
         for type_checker in type_checkers:
             if type_checker is type_check_date:
                 type_guess, subtype_guess, date_fmt = type_checker(element)
-                additional_info['date_fmt'] = date_fmt
+                if type_guess is not None:
+                    additional_info['date_fmt'] = date_fmt
             else:
                 type_guess, subtype_guess = type_checker(element)
 


### PR DESCRIPTION
Closes https://github.com/mindsdb/mindsdb_native/issues/493
Closes https://github.com/mindsdb/mindsdb_native/issues/492

- Add  `'%Y-%m-%d %H:%M:%S.%f'` and `'%m/%d/%y'` to list of supported date formats
- Speed up date subtype detection (fist check if at least one format matches at least one cell, then iterate through all cells and all formats and see which format matches the most cells, and based on which format has the most matches return the subtype [`DATA_SUBTYPES.TIMESTAMP` or `DATA_SUBTYPES.DATE`])
