### PR TITLE
Un-bias procedure off by default

### DIFF
--- a/mindsdb_native/libs/controllers/predictor.py
+++ b/mindsdb_native/libs/controllers/predictor.py
@@ -125,7 +125,7 @@ class Predictor:
                     backend='lightwood',
                     rebuild_model=True,
                     use_gpu=None,
-                    equal_accuracy_for_all_output_categories=True,
+                    equal_accuracy_for_all_output_categories=False,
                     output_categories_importance_dictionary=None,
                     advanced_args=None,
                     sample_settings=None):
@@ -146,7 +146,7 @@ class Predictor:
               backend='lightwood',
               rebuild_model=True,
               use_gpu=None,
-              equal_accuracy_for_all_output_categories=True,
+              equal_accuracy_for_all_output_categories=False,
               output_categories_importance_dictionary=None,
               advanced_args=None,
               sample_settings=None):


### PR DESCRIPTION
## Why
Tests with OpenML and internal benchmarking suites suggest that the `DataTransformer` un-biasing procedure may hinder balanced accuracy. It is a useful behavior, but it might be better to have it disabled by default.

## How
Setting the `equal_accuracy_for_all_output_categories` to `False` by default. 