### PR TITLE
Some time series fixes

### DIFF
--- a/mindsdb_native/libs/helpers/general_helpers.py
+++ b/mindsdb_native/libs/helpers/general_helpers.py
@@ -18,7 +18,6 @@ from sklearn.metrics import (
     r2_score
 )
 
-from lightwood.mixers import NnMixer
 from mindsdb_native.__about__ import __version__
 from mindsdb_native.config import CONFIG
 from mindsdb_native.libs.data_types.mindsdb_logger import log
@@ -205,9 +204,8 @@ def evaluate_regression_accuracy(
         **kwargs
     ):
     if kwargs.get('ts_window', None) is not None and backend.predictor and \
-            isinstance(backend.predictor._mixer, NnMixer) and \
             kwargs['ts_window'] <= 2*len(predictions[column]):
-        # provided enough rows, truncate first 'window' values to account for warmup period in NnMixer
+        # with enough rows, truncate 1st 'window' outputs to account for incomplete historical context
         predictions[column] = predictions[column][kwargs['ts_window']:]
         true_values = true_values[kwargs['ts_window']:]
 

--- a/mindsdb_native/libs/helpers/general_helpers.py
+++ b/mindsdb_native/libs/helpers/general_helpers.py
@@ -205,10 +205,12 @@ def evaluate_regression_accuracy(
         **kwargs
     ):
     if kwargs.get('ts_window', None) is not None and backend.predictor and \
-            isinstance(backend.predictor._mixer, NnMixer):
-        # truncate first window values to account for warmup period in NnMixer
-        predictions[column] = predictions[column][min(kwargs['ts_window'], len(predictions[column])):]
-        true_values = true_values[min(kwargs['ts_window'], len(true_values)):]
+            isinstance(backend.predictor._mixer, NnMixer) and \
+            kwargs['ts_window'] <= 2*len(predictions[column]):
+        # provided enough rows, truncate first 'window' values to account for warmup period in NnMixer
+        predictions[column] = predictions[column][kwargs['ts_window']:]
+        true_values = true_values[kwargs['ts_window']:]
+
     if f'{column}_confidence_range' in predictions:
         Y = np.array(true_values)
         ranges = predictions[f'{column}_confidence_range']

--- a/mindsdb_native/libs/helpers/general_helpers.py
+++ b/mindsdb_native/libs/helpers/general_helpers.py
@@ -18,6 +18,7 @@ from sklearn.metrics import (
     r2_score
 )
 
+from lightwood.mixers import NnMixer
 from mindsdb_native.__about__ import __version__
 from mindsdb_native.config import CONFIG
 from mindsdb_native.libs.data_types.mindsdb_logger import log
@@ -203,6 +204,11 @@ def evaluate_regression_accuracy(
         backend,
         **kwargs
     ):
+    if kwargs.get('ts_window', None) is not None and backend.predictor and \
+            isinstance(backend.predictor._mixer, NnMixer):
+        # truncate first window values to account for warmup period in NnMixer
+        predictions[column] = predictions[column][min(kwargs['ts_window'], len(predictions[column])):]
+        true_values = true_values[min(kwargs['ts_window'], len(true_values)):]
     if f'{column}_confidence_range' in predictions:
         Y = np.array(true_values)
         ranges = predictions[f'{column}_confidence_range']

--- a/mindsdb_native/libs/helpers/general_helpers.py
+++ b/mindsdb_native/libs/helpers/general_helpers.py
@@ -203,8 +203,7 @@ def evaluate_regression_accuracy(
         backend,
         **kwargs
     ):
-    if kwargs.get('ts_window', None) is not None and backend.predictor and \
-            kwargs['ts_window'] <= 2*len(predictions[column]):
+    if kwargs.get('ts_window', None) is not None and kwargs['ts_window'] <= 2*len(predictions[column]):
         # with enough rows, truncate 1st 'window' outputs to account for incomplete historical context
         predictions[column] = predictions[column][kwargs['ts_window']:]
         true_values = true_values[kwargs['ts_window']:]

--- a/mindsdb_native/libs/phases/data_splitter/data_splitter.py
+++ b/mindsdb_native/libs/phases/data_splitter/data_splitter.py
@@ -36,14 +36,14 @@ class DataSplitter(BaseModule):
                 test_indexes[NO_GROUP] = data_split_indexes['test_indexes']
                 validation_indexes[NO_GROUP] = data_split_indexes['validation_indexes']
             else:
+                # for time series, val and test should both have >= 2*nr_predictions rows
+                train_cutoff = max(length * 2 * CONFIG.TEST_TRAIN_RATIO,
+                                   2 * 2 * self.transaction.lmd['tss'].get('nr_predictions', 0))
+
                 if len(group_by) > 0:
                     for group in all_indexes:
                         if group == NO_GROUP: continue
                         length = len(all_indexes[group])
-
-                        # val and test should both have >= 2*nr_predictions rows
-                        train_cutoff = max(length * CONFIG.TEST_TRAIN_RATIO,
-                                       2 * 2 * self.transaction.lmd['tss']['nr_predictions'])
 
                         train_a = 0
                         train_b = round(length - train_cutoff)
@@ -65,11 +65,11 @@ class DataSplitter(BaseModule):
 
                     # make sure that the last in the time series are also the subset used for test
                     train_a = 0
-                    train_b = int(length * (1 - 2 * CONFIG.TEST_TRAIN_RATIO))
+                    train_b = round(length - train_cutoff)
                     train_indexes[NO_GROUP] = all_indexes[NO_GROUP][train_a:train_b]
 
                     valid_a = train_b
-                    valid_b = train_b + int(length * CONFIG.TEST_TRAIN_RATIO)
+                    valid_b = train_b + round(train_cutoff / 2)
                     validation_indexes[NO_GROUP] = all_indexes[NO_GROUP][valid_a:valid_b]
 
                     test_a = valid_b

--- a/mindsdb_native/libs/phases/data_splitter/data_splitter.py
+++ b/mindsdb_native/libs/phases/data_splitter/data_splitter.py
@@ -36,14 +36,14 @@ class DataSplitter(BaseModule):
                 test_indexes[NO_GROUP] = data_split_indexes['test_indexes']
                 validation_indexes[NO_GROUP] = data_split_indexes['validation_indexes']
             else:
-                # for time series, val and test should both have >= 2*nr_predictions rows
-                train_cutoff = max(length * 2 * CONFIG.TEST_TRAIN_RATIO,
-                                   2 * 2 * self.transaction.lmd['tss'].get('nr_predictions', 0))
 
                 if len(group_by) > 0:
                     for group in all_indexes:
                         if group == NO_GROUP: continue
                         length = len(all_indexes[group])
+                        # for time series, val and test should both have >= 2*nr_predictions rows
+                        train_cutoff = max(length * 2 * CONFIG.TEST_TRAIN_RATIO,
+                                           2 * 2 * self.transaction.lmd['tss'].get('nr_predictions', 0))
 
                         train_a = 0
                         train_b = round(length - train_cutoff)
@@ -62,6 +62,8 @@ class DataSplitter(BaseModule):
                         validation_indexes[NO_GROUP].extend(validation_indexes[group])
                 else:
                     length = len(all_indexes[NO_GROUP])
+                    train_cutoff = max(length * 2 * CONFIG.TEST_TRAIN_RATIO,
+                                       2 * 2 * self.transaction.lmd['tss'].get('nr_predictions', 0))
 
                     # make sure that the last in the time series are also the subset used for test
                     train_a = 0

--- a/mindsdb_native/libs/phases/data_splitter/data_splitter.py
+++ b/mindsdb_native/libs/phases/data_splitter/data_splitter.py
@@ -41,12 +41,16 @@ class DataSplitter(BaseModule):
                         if group == NO_GROUP: continue
                         length = len(all_indexes[group])
 
+                        # val and test should both have >= 2*nr_predictions rows
+                        train_cutoff = max(length * CONFIG.TEST_TRAIN_RATIO,
+                                       2 * 2 * self.transaction.lmd['tss']['nr_predictions'])
+
                         train_a = 0
-                        train_b = round(length - length * CONFIG.TEST_TRAIN_RATIO)
+                        train_b = round(length - train_cutoff)
                         train_indexes[group] = all_indexes[group][train_a:train_b]
 
                         test_a = train_b
-                        test_b = train_b + round(length * CONFIG.TEST_TRAIN_RATIO / 2)
+                        test_b = train_b + round(train_cutoff / 2)
                         test_indexes[group] = all_indexes[group][test_a:test_b]
 
                         valid_a = test_b

--- a/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
+++ b/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
@@ -72,7 +72,7 @@ def _ts_add_previous_target(df, predict_columns, nr_predictions, window):
         for timestep_index in range(1, nr_predictions):
             next_target_value_arr = list(df[target_column])
             for del_index in range(0, min(timestep_index, len(next_target_value_arr))):
-                del next_target_value_arr[del_index]
+                del next_target_value_arr[0]
                 next_target_value_arr.append(0)
             # @TODO: Maybe ignore the rows with `None` next targets for training
             df[f'{target_column}_timestep_{timestep_index}'] = next_target_value_arr

--- a/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
+++ b/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
@@ -74,15 +74,20 @@ def _ts_add_previous_target(df, predict_columns, nr_predictions, window):
             for del_index in range(0, min(timestep_index, len(next_target_value_arr))):
                 del next_target_value_arr[0]
                 next_target_value_arr.append(None)
-            # @TODO: Maybe ignore the rows with `None` next targets for training
             df[f'{target_column}_timestep_{timestep_index}'] = next_target_value_arr
 
     # drop rows with incomplete target info. (last nr_prediction rows per each group in time series tasks)
-    df = df.dropna(axis=0,
-                   how='any',
-                   subset=[f'{target_column}_timestep_{i}'
-                           for target_column in predict_columns
-                           for i in range(1, nr_predictions)])
+    # df = df.dropna(axis=0,
+    #                how='any',
+    #                subset=[f'{target_column}_timestep_{i}'
+    #                        for target_column in predict_columns
+    #                        for i in range(1, nr_predictions)])
+    for target_column in predict_columns:
+        for col in [f'{target_column}_timestep_{i}' for i in range(1, nr_predictions)]:
+            if 'make_predictions' not in df.columns:
+                df['make_predictions'] = True
+            df['make_predictions'][df[col].isna()] = False
+            # df.loc[df[col].isna(), ['make_predictions']] = False
 
     return df
 

--- a/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
+++ b/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
@@ -503,7 +503,7 @@ class LightwoodBackend:
 
                 if self.transaction.lmd['tss']['is_timeseries']:
                     validation_df = self.transaction.input_data.validation_df[self.transaction.input_data.validation_df['make_predictions'] == True]
-                    ts_window = self.transaction.lmd['tss'].get('window', 1)
+                    ts_window = self.transaction.lmd['tss'].get('window', 0)
                 else:
                     ts_window = 0
 

--- a/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
+++ b/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
@@ -503,13 +503,17 @@ class LightwoodBackend:
 
                 if self.transaction.lmd['tss']['is_timeseries']:
                     validation_df = self.transaction.input_data.validation_df[self.transaction.input_data.validation_df['make_predictions'] == True]
+                    ts_window = self.transaction.lmd['tss'].get('window', 1)
+                else:
+                    ts_window = 0
 
                 validation_accuracy = evaluate_accuracy(
                     validation_predictions,
                     validation_df,
                     self.transaction.lmd['stats_v2'],
                     self.transaction.lmd['predict_columns'],
-                    backend=self
+                    backend=self,
+                    ts_window=ts_window
                 )
 
                 predictors_and_accuracies.append((

--- a/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
+++ b/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
@@ -81,7 +81,7 @@ def _ts_add_previous_target(df, predict_columns, nr_predictions, window):
         for col in [f'{target_column}_timestep_{i}' for i in range(1, nr_predictions)]:
             if 'make_predictions' not in df.columns:
                 df['make_predictions'] = True
-            df['make_predictions'][df[col].isna()] = False
+            df.loc[df[col].isna(), ['make_predictions']] = False
 
     return df
 

--- a/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
+++ b/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
@@ -76,18 +76,12 @@ def _ts_add_previous_target(df, predict_columns, nr_predictions, window):
                 next_target_value_arr.append(None)
             df[f'{target_column}_timestep_{timestep_index}'] = next_target_value_arr
 
-    # drop rows with incomplete target info. (last nr_prediction rows per each group in time series tasks)
-    # df = df.dropna(axis=0,
-    #                how='any',
-    #                subset=[f'{target_column}_timestep_{i}'
-    #                        for target_column in predict_columns
-    #                        for i in range(1, nr_predictions)])
+    # drop rows with incomplete target info.
     for target_column in predict_columns:
         for col in [f'{target_column}_timestep_{i}' for i in range(1, nr_predictions)]:
             if 'make_predictions' not in df.columns:
                 df['make_predictions'] = True
             df['make_predictions'][df[col].isna()] = False
-            # df.loc[df[col].isna(), ['make_predictions']] = False
 
     return df
 

--- a/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
+++ b/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
@@ -513,7 +513,7 @@ class LightwoodBackend:
                     validation_df = self.transaction.input_data.validation_df[self.transaction.input_data.validation_df['make_predictions'] == True]
                     ts_window = self.transaction.lmd['tss'].get('window', 0)
                 else:
-                    ts_window = 0
+                    ts_window = None
 
                 validation_accuracy = evaluate_accuracy(
                     validation_predictions,

--- a/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
+++ b/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
@@ -73,9 +73,17 @@ def _ts_add_previous_target(df, predict_columns, nr_predictions, window):
             next_target_value_arr = list(df[target_column])
             for del_index in range(0, min(timestep_index, len(next_target_value_arr))):
                 del next_target_value_arr[0]
-                next_target_value_arr.append(0)
+                next_target_value_arr.append(None)
             # @TODO: Maybe ignore the rows with `None` next targets for training
             df[f'{target_column}_timestep_{timestep_index}'] = next_target_value_arr
+
+    # drop rows with incomplete target info. (last nr_prediction rows per each group in time series tasks)
+    df = df.dropna(axis=0,
+                   how='any',
+                   subset=[f'{target_column}_timestep_{i}'
+                           for target_column in predict_columns
+                           for i in range(1, nr_predictions)])
+
     return df
 
 

--- a/tests/unit_tests/libs/controllers/test_predictor_timeseries.py
+++ b/tests/unit_tests/libs/controllers/test_predictor_timeseries.py
@@ -255,7 +255,8 @@ class TestPredictorTimeseries(unittest.TestCase):
                     df,
                     ['a'],
                     nr_predictions=nr_predictions,
-                    window=window
+                    window=window,
+                    mode='learn'
                 )
 
                 for x in new_df['__mdb_ts_previous_a']:


### PR DESCRIPTION
## Why

To improve MindsDB accuracy and performance in time series tasks

## How

Changelog:
- Do not consider rows with incomplete historical context when calculating accuracy
- Changed data splitter criteria to have complete target info. for all rows (this is relevant when doing `t+n ; n>1` forecasts). A problem with the current behavior is that, depending on the granularity of the grouped series, null values can be passed as targets, yielding incorrect supervision in the predictor. This is fixed now. 