### PR TITLE
Release

### DIFF
--- a/mindsdb_native/__about__.py
+++ b/mindsdb_native/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'mindsdb_native'
 __package_name__ = 'mindsdb_native'
-__version__ = '2.43.0'
+__version__ = '2.44.0'
 __description__ = "MindsDB's goal is to make it very simple for developers to use the power of artificial neural networks in their projects."
 __email__ = "jorge@mindsdb.com"
 __author__ = 'MindsDB Inc'

--- a/mindsdb_native/libs/helpers/mp_helpers.py
+++ b/mindsdb_native/libs/helpers/mp_helpers.py
@@ -14,8 +14,7 @@ def get_nr_procs(max_processes=None, max_per_proc_usage=None, df=None):
                 import ray
                 max_per_proc_usage = 0.2 * pow(10,9)
             except:
-                max_per_proc_usage = 4 * pow(10, 9)
-            print(f'\n\n\n\n{max_per_proc_usage}\n\n\n\n')
+                max_per_proc_usage = 3 * pow(10, 9)
             if df is not None:
                 max_per_proc_usage += df.memory_usage(index=True, deep=True).sum()
         proc_count = int(min(mp.cpu_count(), available_mem // max_per_proc_usage)) - 1

--- a/mindsdb_native/libs/helpers/mp_helpers.py
+++ b/mindsdb_native/libs/helpers/mp_helpers.py
@@ -13,7 +13,7 @@ def get_nr_procs(max_processes=None, max_per_proc_usage=None, df=None):
                 import mindsdb_worker
                 max_per_proc_usage = 0.2 * pow(10,9)
             except:
-                max_per_proc_usage = 4 * pow(10, 9)
+                max_per_proc_usage = 2.6 * pow(10, 9)
 
             if df is not None:
                 max_per_proc_usage += df.memory_usage(index=True, deep=True).sum()

--- a/mindsdb_native/libs/helpers/mp_helpers.py
+++ b/mindsdb_native/libs/helpers/mp_helpers.py
@@ -13,7 +13,7 @@ def get_nr_procs(max_processes=None, max_per_proc_usage=None, df=None):
                 import mindsdb_worker
                 max_per_proc_usage = 0.2 * pow(10,9)
             except:
-                max_per_proc_usage = 2.6 * pow(10, 9)
+                max_per_proc_usage = 4 * pow(10, 9)
 
             if df is not None:
                 max_per_proc_usage += df.memory_usage(index=True, deep=True).sum()

--- a/mindsdb_native/libs/helpers/mp_helpers.py
+++ b/mindsdb_native/libs/helpers/mp_helpers.py
@@ -11,10 +11,11 @@ def get_nr_procs(max_processes=None, max_per_proc_usage=None, df=None):
         if max_per_proc_usage is None or type(max_per_proc_usage) not in (int, float):
             try:
                 import mindsdb_worker
+                import ray
                 max_per_proc_usage = 0.2 * pow(10,9)
             except:
-                max_per_proc_usage = 2.6 * pow(10, 9)
-
+                max_per_proc_usage = 4 * pow(10, 9)
+            print(f'\n\n\n\n{max_per_proc_usage}\n\n\n\n')
             if df is not None:
                 max_per_proc_usage += df.memory_usage(index=True, deep=True).sum()
         proc_count = int(min(mp.cpu_count(), available_mem // max_per_proc_usage)) - 1


### PR DESCRIPTION
Just a fairly minor fix that should (mainly) affect dev envs and cloud envs: Set low-per-proc memory expectation only if ray *and* mindsdb_worker both are importable. Otherwise there are cases where mindsdb_worker exists and can be imported but ray doesn't.