### PR TITLE
Fix grouped TS row splits & ICP cache for classifiers

### DIFF
--- a/mindsdb_native/libs/phases/data_splitter/data_splitter.py
+++ b/mindsdb_native/libs/phases/data_splitter/data_splitter.py
@@ -50,7 +50,7 @@ class DataSplitter(BaseModule):
                         train_indexes[group] = all_indexes[group][train_a:train_b]
 
                         test_a = train_b
-                        test_b = train_b + max(0, round(train_cutoff / 2))
+                        test_b = test_a + max(test_a, round(train_cutoff / 2))
                         test_indexes[group] = all_indexes[group][test_a:test_b]
 
                         valid_a = test_b

--- a/mindsdb_native/libs/phases/data_splitter/data_splitter.py
+++ b/mindsdb_native/libs/phases/data_splitter/data_splitter.py
@@ -46,11 +46,11 @@ class DataSplitter(BaseModule):
                                            2 * 2 * self.transaction.lmd['tss'].get('nr_predictions', 0))
 
                         train_a = 0
-                        train_b = max(train_a, round(length - train_cutoff))
+                        train_b = max(0, round(length - train_cutoff))
                         train_indexes[group] = all_indexes[group][train_a:train_b]
 
                         test_a = train_b
-                        test_b = test_a + max(test_a, round(train_cutoff / 2))
+                        test_b = test_a + max(0, round(train_cutoff / 2))
                         test_indexes[group] = all_indexes[group][test_a:test_b]
 
                         valid_a = test_b

--- a/mindsdb_native/libs/phases/data_splitter/data_splitter.py
+++ b/mindsdb_native/libs/phases/data_splitter/data_splitter.py
@@ -46,11 +46,11 @@ class DataSplitter(BaseModule):
                                            2 * 2 * self.transaction.lmd['tss'].get('nr_predictions', 0))
 
                         train_a = 0
-                        train_b = round(length - train_cutoff)
+                        train_b = max(train_a, round(length - train_cutoff))
                         train_indexes[group] = all_indexes[group][train_a:train_b]
 
                         test_a = train_b
-                        test_b = train_b + round(train_cutoff / 2)
+                        test_b = train_b + max(0, round(train_cutoff / 2))
                         test_indexes[group] = all_indexes[group][test_a:test_b]
 
                         valid_a = test_b

--- a/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
+++ b/mindsdb_native/libs/phases/model_analyzer/model_analyzer.py
@@ -164,6 +164,8 @@ class ModelAnalyzer(BaseModule):
                     icps_df = deepcopy(self.transaction.input_data.cached_val_df)
                     if is_multi_ts:
                         icps_df[f'__predicted_{target}'] = [p[0] for p in normal_predictions[target]]
+                    elif is_classification:
+                        icps_df[f'__predicted_{target}'] = normal_predictions[f'{target}_class_distribution']
                     else:
                         icps_df[f'__predicted_{target}'] = normal_predictions[target]
 
@@ -179,6 +181,8 @@ class ModelAnalyzer(BaseModule):
 
                         # save relevant predictions in the caches, then calibrate the ICP
                         pred_cache = icp_df.pop(f'__predicted_{target}').values
+                        if is_classification:
+                            pred_cache = np.vstack(pred_cache)
                         icps[frozenset(group)].nc_function.model.prediction_cache = pred_cache
                         icp_df, y = clean_df(icp_df, target, self.transaction, is_classification, fit_params)
                         if icps[frozenset(group)].nc_function.normalizer is not None:


### PR DESCRIPTION
## Why
To fix `ValueError`s that could occasionally pop up in time series tasks

## How
- Fixed the train-val-test split indexes so that upper bound is never smaller than lower bound for each split
- Retrieve class distribution for grouped TS tasks with categorical targets