### PR TITLE
Improved time series predictions for future timestamps

### DIFF
--- a/mindsdb_native/libs/controllers/transaction.py
+++ b/mindsdb_native/libs/controllers/transaction.py
@@ -358,9 +358,7 @@ class PredictTransaction(Transaction):
         output_data = {col: [] for col in self.lmd['columns']}
 
         if 'make_predictions' in self.input_data.data_frame.columns:
-            to_predict = self.input_data.data_frame[self.input_data.data_frame['make_predictions'] == True]
-            if to_predict.shape[0] == 0:
-                # assume infer mode, get cached DF with new rows
+            if self.lmd['tss'].get('infer_mode', False):
                 predictions_df = self.input_data.cached_pred_df
             else:
                 predictions_df = pd.DataFrame(
@@ -547,6 +545,9 @@ class PredictTransaction(Transaction):
             for predicted_col in self.lmd['predict_columns']:
                 output_data[f'{predicted_col}_confidence'] = [None] * len(output_data[predicted_col])
                 output_data[f'{predicted_col}_confidence_range'] = [[None, None]] * len(output_data[predicted_col])
+
+        if self.lmd['tss'].get('infer_mode', False):
+            output_data = reformat_inferred(output_data, self.lmd['tss'], self.lmd['predict_columns'])
 
         self.output_data = PredictTransactionOutputData(
             transaction=self,

--- a/mindsdb_native/libs/controllers/transaction.py
+++ b/mindsdb_native/libs/controllers/transaction.py
@@ -1,5 +1,6 @@
 from mindsdb_native.libs.helpers.general_helpers import *
-from mindsdb_native.libs.helpers.confidence_helpers import get_numerical_conf_range, get_categorical_conf, get_anomalies
+from mindsdb_native.libs.helpers.confidence_helpers import get_numerical_conf_range, get_categorical_conf
+from mindsdb_native.libs.helpers.confidence_helpers import add_tn_conf_bounds, get_anomalies
 from mindsdb_native.libs.helpers.conformal_helpers import restore_icp_state, clear_icp_state
 from mindsdb_native.libs.data_types.transaction_data import TransactionData
 from mindsdb_native.libs.data_types.transaction_output_data import (
@@ -548,6 +549,8 @@ class PredictTransaction(Transaction):
                 output_data[f'{predicted_col}_confidence'] = [None] * len(output_data[predicted_col])
                 output_data[f'{predicted_col}_confidence_range'] = [[None, None]] * len(output_data[predicted_col])
 
+        if self.lmd['tss'].get('nr_predictions', 1) > 1:
+            output_data = add_tn_conf_bounds(output_data, self.lmd['tss'], self.lmd['predict_columns'], dtypes)
         if self.lmd['tss'].get('infer_mode', False):
             output_data = reformat_inferred(output_data, self.lmd['tss'], self.lmd['predict_columns'], dtypes)
 

--- a/mindsdb_native/libs/controllers/transaction.py
+++ b/mindsdb_native/libs/controllers/transaction.py
@@ -547,7 +547,7 @@ class PredictTransaction(Transaction):
                 output_data[f'{predicted_col}_confidence_range'] = [[None, None]] * len(output_data[predicted_col])
 
         if self.lmd['tss'].get('infer_mode', False):
-            output_data = reformat_inferred(output_data, self.lmd['tss'], self.lmd['predict_columns'])
+            output_data = reformat_inferred(output_data, self.lmd['tss'])
 
         self.output_data = PredictTransactionOutputData(
             transaction=self,

--- a/mindsdb_native/libs/data_types/transaction_output_row.py
+++ b/mindsdb_native/libs/data_types/transaction_output_row.py
@@ -74,7 +74,11 @@ class TransactionOutputRow:
                 answers[pred_col]['anomaly'] = prediction_row[f'{pred_col}_anomaly']
 
             if prediction_row.get(f'{pred_col}_confidence') is not None:
-                answers[pred_col]['confidence'] = round(prediction_row[f'{pred_col}_confidence'], 4)
+                if isinstance(prediction_row.get(f'{pred_col}_confidence'), list):
+                    # for T+N predictors, consider the 1st confidence only
+                    answers[pred_col]['confidence'] = round(prediction_row[f'{pred_col}_confidence'][0], 4)
+                else:
+                    answers[pred_col]['confidence'] = round(prediction_row[f'{pred_col}_confidence'], 4)
                 quality = 'very confident'
                 if answers[pred_col]['confidence'] < 0.8:
                     quality = 'confident'

--- a/mindsdb_native/libs/helpers/confidence_helpers.py
+++ b/mindsdb_native/libs/helpers/confidence_helpers.py
@@ -172,3 +172,21 @@ def get_anomalies(bounds, observed_series, cooldown=1):
             counter += 1
 
     return anomalies
+
+
+def add_tn_conf_bounds(data, tss_args, target_cols, dtypes):
+    """
+    Add confidence (and bounds where applicable) to t+n predictions, for n>1
+        @TODO: active research question: how to guarantee 1-e coverage for t+n, n>1
+        for now, we replicate the width and conf obtained for t+1
+    """
+    for idx in range(len(data[tss_args['order_by'][0]])):
+        for target in target_cols:
+            conf = data[f'{target}_confidence'][idx]
+            data[f'{target}_confidence'][idx] = [conf for _ in range(tss_args['nr_predictions'])]
+
+            if dtypes[target]['numerical']:
+                width = data[f'{target}_confidence_range'][idx][1] - data[f'{target}_confidence_range'][idx][0]
+                data[f'{target}_confidence_range'][idx] = [[pred - width / 2, pred + width / 2] for pred in
+                                                           data[target][idx]]
+    return data

--- a/mindsdb_native/libs/helpers/general_helpers.py
+++ b/mindsdb_native/libs/helpers/general_helpers.py
@@ -372,3 +372,20 @@ def load_hmd(path):
     if 'breakpoint' not in hmd:
         hmd['breakpoint'] = None
     return hmd
+
+
+def reformat_inferred(data, tss_args):
+    """
+    Modifies output data whenever time series inferring mode is activated:
+        - Change timestamps in `order_by` col to future values that the predictions belong to.
+    """
+    for idx in range(len(data[tss_args['order_by'][0]])):
+        order_sample = data[tss_args['order_by'][0]][idx]
+
+        # assumes regular intervals between series points
+        interval = order_sample[-1] - order_sample[-2]
+
+        future_timestamps = [order_sample[-1] + interval*i for i in range(tss_args['nr_predictions'])]
+        data[tss_args['order_by'][0]][idx] = future_timestamps
+
+    return data

--- a/mindsdb_native/libs/helpers/general_helpers.py
+++ b/mindsdb_native/libs/helpers/general_helpers.py
@@ -378,10 +378,6 @@ def reformat_inferred(data, tss_args, target_cols, dtypes):
     """
     Modifies output data whenever time series inferring mode is activated:
         - Change timestamps in `order_by` col to future values that the predictions belong to.
-        - Add confidence (and bounds where applicable) to t+n predictions, for n>1
-            @TODO: active research question: how to guarantee 1-e coverage for t+n, n>1
-            for now, we replicate the width and conf obtained for t+1
-
     """
     for idx in range(len(data[tss_args['order_by'][0]])):
         order_sample = data[tss_args['order_by'][0]][idx]
@@ -391,13 +387,5 @@ def reformat_inferred(data, tss_args, target_cols, dtypes):
 
         future_timestamps = [order_sample[-1] + interval*i for i in range(tss_args['nr_predictions'])]
         data[tss_args['order_by'][0]][idx] = future_timestamps
-
-        for target in target_cols:
-            conf = data[f'{target}_confidence'][idx]
-            data[f'{target}_confidence'][idx] = [conf for _ in range(tss_args['nr_predictions'])]
-
-            if dtypes[target]['numerical']:
-                width = data[f'{target}_confidence_range'][idx][1] - data[f'{target}_confidence_range'][idx][0]
-                data[f'{target}_confidence_range'][idx] = [[pred-width/2, pred+width/2] for pred in data[target][idx]]
 
     return data

--- a/mindsdb_native/libs/helpers/general_helpers.py
+++ b/mindsdb_native/libs/helpers/general_helpers.py
@@ -374,10 +374,14 @@ def load_hmd(path):
     return hmd
 
 
-def reformat_inferred(data, tss_args):
+def reformat_inferred(data, tss_args, target_cols, dtypes):
     """
     Modifies output data whenever time series inferring mode is activated:
         - Change timestamps in `order_by` col to future values that the predictions belong to.
+        - Add confidence (and bounds where applicable) to t+n predictions, for n>1
+            @TODO: active research question: how to guarantee 1-e coverage for t+n, n>1
+            for now, we replicate the width and conf obtained for t+1
+
     """
     for idx in range(len(data[tss_args['order_by'][0]])):
         order_sample = data[tss_args['order_by'][0]][idx]
@@ -387,5 +391,13 @@ def reformat_inferred(data, tss_args):
 
         future_timestamps = [order_sample[-1] + interval*i for i in range(tss_args['nr_predictions'])]
         data[tss_args['order_by'][0]][idx] = future_timestamps
+
+        for target in target_cols:
+            conf = data[f'{target}_confidence'][idx]
+            data[f'{target}_confidence'][idx] = [conf for _ in range(tss_args['nr_predictions'])]
+
+            if dtypes[target]['numerical']:
+                width = data[f'{target}_confidence_range'][idx][1] - data[f'{target}_confidence_range'][idx][0]
+                data[f'{target}_confidence_range'][idx] = [[pred-width/2, pred+width/2] for pred in data[target][idx]]
 
     return data

--- a/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
+++ b/mindsdb_native/libs/phases/model_interface/lightwood_backend.py
@@ -122,6 +122,9 @@ class LightwoodBackend:
             infer_mode = index.shape[0] == 0  # condition to trigger: make_predictions is set to False everywhere
         else:
             infer_mode = False
+
+        self.transaction.lmd['tss']['infer_mode'] = infer_mode
+
         original_index_list = []
         idx = 0
         for row in original_df.itertuples():


### PR DESCRIPTION
## Why
To get a more sensible output when using the `infer_mode` for predicting values further into the future than what the data source input to `.predict()` offers.

## How
- Reformat output timestamps so that they correspond directly with the forecasted quantity. 
- Add confidence (and bounds if applicable) to all `n` predicted data points (`n` is defined at training time with the `nr_predictions` argument). It's important to note that the statistical guarantees offered by the conformal prediction framework do not hold for these additional data points. Doing so is an _open research question_.
 

## Example


### Current behavior
To illustrate the changes, assume a predictor with `nr_predictions=4 ; window=3`  and that the latest timestamp in the `when_data` dataframe is `1342051200` with `7862400`-wide intervals (that is, quarterly frequency).

The `predict()` output previous to this PR:

```
{'T': [[1326326400.0, 1334188800.0, 1342051200.0, 1349913600.0],
  [1326326400.0, 1334188800.0, 1342051200.0, 1349913600.0],
  [1326326400.0, 1334188800.0, 1342051200.0, 1349913600.0],
  [1326326400.0, 1334188800.0, 1342051200.0, 1349913600.0]],
 'Country': ['Japan', 'NZ', 'UK', 'US'],
 'Traffic': [[115332, 104071, 71530, 94848],
  [324261, 259259, 270811, 325602],
  [174730, 195126, 97320, 105799],
  [117756, 136044, 104274, 110466]],
 '__observed_Traffic': [101900, 319840, 101690, 106540],
 'Traffic_confidence': [0.08, 0.08, 0.08, 0.08],
 'Traffic_confidence_range': [[86393.34343434343, 144270.65656565657],
  [295322.34343434346, 353199.65656565654],
  [145791.34343434343, 203668.65656565657],
  [88817.34343434343, 146694.65656565657]],
 'Traffic_anomaly': [False, False, True, False]}
```

Note that the output contains `nr_predictions=4` forecasted points for each group/series (as determined by the `group_by: Country` column), and that the latest timestamp in each row (`1349913600=October 2012`) corresponds to the quarter that follows the latest point in the input data frame (`1342051200=July 2012`).

However, this format is confusing because of the mismatch between timestamps and the forecasts. Why? Well, because the predictions in the `Traffic` key _start_ from `1349913600` and assume regularly spaced intervals moving forward, but crucially, MDB Native is not returning what those timestamps are.

Another undesirable fact: confidence and confidence ranges are available only for the first forecast in each row.


### New behavior
The output with the changes introduced in this PR:

```
{'T': [[1349913600.0, 1357776000.0, 1365638400.0, 1373500800.0],
  [1349913600.0, 1357776000.0, 1365638400.0, 1373500800.0],
  [1349913600.0, 1357776000.0, 1365638400.0, 1373500800.0],
  [1349913600.0, 1357776000.0, 1365638400.0, 1373500800.0]],
 'Country': ['Japan', 'NZ', 'UK', 'US'],
 'Traffic': [[115332, 104071, 71530, 94848],
  [324261, 259259, 270811, 325602],
  [174730, 195126, 97320, 105799],
  [117756, 136044, 104274, 110466]],
 '__observed_Traffic': [101900, 319840, 101690, 106540],
 'Traffic_confidence': [[0.08, 0.08, 0.08, 0.08],
  [0.08, 0.08, 0.08, 0.08],
  [0.08, 0.08, 0.08, 0.08],
  [0.08, 0.08, 0.08, 0.08]],
 'Traffic_confidence_range': [[[86393.34343434343, 144270.65656565657],
   [75132.34343434343, 133009.65656565657],
   [42591.343434343435, 100468.65656565657],
   [65909.34343434343, 123786.65656565657]],
  [[295322.34343434346, 353199.65656565654],
   [230320.34343434346, 288197.65656565654],
   [241872.34343434346, 299749.65656565654],
   [296663.34343434346, 354540.65656565654]],
  [[145791.34343434343, 203668.65656565657],
   [166187.34343434343, 224064.65656565657],
   [68381.34343434343, 126258.65656565657],
   [76860.34343434343, 134737.65656565657]],
  [[88817.34343434343, 146694.65656565657],
   [107105.34343434343, 164982.65656565657],
   [75335.34343434343, 133212.65656565657],
   [81527.34343434343, 139404.65656565657]]],
 'Traffic_anomaly': [False, False, True, False]}
```

We see that now the timestamps do match the predicted quantity, starting from `1349913600=October 2012` all the way to `1373500800=July 2013`, forecasting a full year as specified in `learn`.

Additionally, both confidence and confidence ranges have been turned into arrays that have this information for all `4` predictions, though guarantees made by the ICP framework do not hold for any predictions other than the very first one, for each row.

Lastly, `infer mode` assumes there is no true data available to compare all forecasts, so the `{target}_anomaly` and `__observed_{target}` keys operate on the assumption that the last seen value will hold, and subsequently apply the criterion only for the first forecast, hence why those keys still have lists of values, rather than nested lists. This bit is important for stream integrations to work.